### PR TITLE
[Sol] Step02-3 - 카드덱 구현하기 + 테스트

### DIFF
--- a/PockerGameApp/PockerGameApp.xcodeproj/project.pbxproj
+++ b/PockerGameApp/PockerGameApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		020FBEF127C328CA00A794D9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 020FBEF027C328CA00A794D9 /* Assets.xcassets */; };
 		020FBEF427C328CA00A794D9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 020FBEF227C328CA00A794D9 /* LaunchScreen.storyboard */; };
 		020FBEFE27C38E6C00A794D9 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020FBEFD27C38E6C00A794D9 /* Card.swift */; };
+		02227AFB27C4AC8B00E7CFC5 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02227AFA27C4AC8B00E7CFC5 /* CardDeck.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		020FBEF327C328CA00A794D9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		020FBEF527C328CA00A794D9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		020FBEFD27C38E6C00A794D9 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+		02227AFA27C4AC8B00E7CFC5 /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +64,7 @@
 				020FBEE927C328C800A794D9 /* SceneDelegate.swift */,
 				020FBEEB27C328C800A794D9 /* ViewController.swift */,
 				020FBEFD27C38E6C00A794D9 /* Card.swift */,
+				02227AFA27C4AC8B00E7CFC5 /* CardDeck.swift */,
 				020FBEED27C328C800A794D9 /* Main.storyboard */,
 				020FBEF027C328CA00A794D9 /* Assets.xcassets */,
 				020FBEF227C328CA00A794D9 /* LaunchScreen.storyboard */,
@@ -142,6 +145,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				020FBEEC27C328C800A794D9 /* ViewController.swift in Sources */,
+				02227AFB27C4AC8B00E7CFC5 /* CardDeck.swift in Sources */,
 				020FBEE827C328C800A794D9 /* AppDelegate.swift in Sources */,
 				020FBEEA27C328C800A794D9 /* SceneDelegate.swift in Sources */,
 				020FBEFE27C38E6C00A794D9 /* Card.swift in Sources */,

--- a/PockerGameApp/PockerGameApp.xcodeproj/project.pbxproj
+++ b/PockerGameApp/PockerGameApp.xcodeproj/project.pbxproj
@@ -15,7 +15,18 @@
 		020FBEF427C328CA00A794D9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 020FBEF227C328CA00A794D9 /* LaunchScreen.storyboard */; };
 		020FBEFE27C38E6C00A794D9 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020FBEFD27C38E6C00A794D9 /* Card.swift */; };
 		02227AFB27C4AC8B00E7CFC5 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02227AFA27C4AC8B00E7CFC5 /* CardDeck.swift */; };
+		02227B0327C4ADD300E7CFC5 /* PockerGameAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02227B0227C4ADD300E7CFC5 /* PockerGameAppTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		02227B0427C4ADD300E7CFC5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 020FBEDC27C328C800A794D9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 020FBEE327C328C800A794D9;
+			remoteInfo = PockerGameApp;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		020FBEE427C328C800A794D9 /* PockerGameApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PockerGameApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -28,10 +39,19 @@
 		020FBEF527C328CA00A794D9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		020FBEFD27C38E6C00A794D9 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		02227AFA27C4AC8B00E7CFC5 /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
+		02227B0027C4ADD300E7CFC5 /* PockerGameAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PockerGameAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		02227B0227C4ADD300E7CFC5 /* PockerGameAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PockerGameAppTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		020FBEE127C328C800A794D9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		02227AFD27C4ADD300E7CFC5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -45,6 +65,7 @@
 			isa = PBXGroup;
 			children = (
 				020FBEE627C328C800A794D9 /* PockerGameApp */,
+				02227B0127C4ADD300E7CFC5 /* PockerGameAppTests */,
 				020FBEE527C328C800A794D9 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -53,6 +74,7 @@
 			isa = PBXGroup;
 			children = (
 				020FBEE427C328C800A794D9 /* PockerGameApp.app */,
+				02227B0027C4ADD300E7CFC5 /* PockerGameAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -71,6 +93,14 @@
 				020FBEF527C328CA00A794D9 /* Info.plist */,
 			);
 			path = PockerGameApp;
+			sourceTree = "<group>";
+		};
+		02227B0127C4ADD300E7CFC5 /* PockerGameAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				02227B0227C4ADD300E7CFC5 /* PockerGameAppTests.swift */,
+			);
+			path = PockerGameAppTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -93,6 +123,24 @@
 			productReference = 020FBEE427C328C800A794D9 /* PockerGameApp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		02227AFF27C4ADD300E7CFC5 /* PockerGameAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 02227B0627C4ADD300E7CFC5 /* Build configuration list for PBXNativeTarget "PockerGameAppTests" */;
+			buildPhases = (
+				02227AFC27C4ADD300E7CFC5 /* Sources */,
+				02227AFD27C4ADD300E7CFC5 /* Frameworks */,
+				02227AFE27C4ADD300E7CFC5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				02227B0527C4ADD300E7CFC5 /* PBXTargetDependency */,
+			);
+			name = PockerGameAppTests;
+			productName = PockerGameAppTests;
+			productReference = 02227B0027C4ADD300E7CFC5 /* PockerGameAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -105,6 +153,10 @@
 				TargetAttributes = {
 					020FBEE327C328C800A794D9 = {
 						CreatedOnToolsVersion = 13.2.1;
+					};
+					02227AFF27C4ADD300E7CFC5 = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = 020FBEE327C328C800A794D9;
 					};
 				};
 			};
@@ -122,6 +174,7 @@
 			projectRoot = "";
 			targets = (
 				020FBEE327C328C800A794D9 /* PockerGameApp */,
+				02227AFF27C4ADD300E7CFC5 /* PockerGameAppTests */,
 			);
 		};
 /* End PBXProject section */
@@ -134,6 +187,13 @@
 				020FBEF427C328CA00A794D9 /* LaunchScreen.storyboard in Resources */,
 				020FBEF127C328CA00A794D9 /* Assets.xcassets in Resources */,
 				020FBEEF27C328C800A794D9 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		02227AFE27C4ADD300E7CFC5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -152,7 +212,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		02227AFC27C4ADD300E7CFC5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				02227B0327C4ADD300E7CFC5 /* PockerGameAppTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		02227B0527C4ADD300E7CFC5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 020FBEE327C328C800A794D9 /* PockerGameApp */;
+			targetProxy = 02227B0427C4ADD300E7CFC5 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		020FBEED27C328C800A794D9 /* Main.storyboard */ = {
@@ -344,6 +420,40 @@
 			};
 			name = Release;
 		};
+		02227B0727C4ADD300E7CFC5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Sol.PockerGameAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PockerGameApp.app/PockerGameApp";
+			};
+			name = Debug;
+		};
+		02227B0827C4ADD300E7CFC5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Sol.PockerGameAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PockerGameApp.app/PockerGameApp";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -361,6 +471,15 @@
 			buildConfigurations = (
 				020FBEF927C328CA00A794D9 /* Debug */,
 				020FBEFA27C328CA00A794D9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		02227B0627C4ADD300E7CFC5 /* Build configuration list for PBXNativeTarget "PockerGameAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				02227B0727C4ADD300E7CFC5 /* Debug */,
+				02227B0827C4ADD300E7CFC5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PockerGameApp/PockerGameApp.xcodeproj/xcshareddata/xcschemes/PockerGameApp.xcscheme
+++ b/PockerGameApp/PockerGameApp.xcodeproj/xcshareddata/xcschemes/PockerGameApp.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "02227AFF27C4ADD300E7CFC5"
+               BuildableName = "PockerGameAppTests.xctest"
+               BlueprintName = "PockerGameAppTests"
+               ReferencedContainer = "container:PockerGameApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/PockerGameApp/PockerGameApp/Card.swift
+++ b/PockerGameApp/PockerGameApp/Card.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class Card {
     
-    enum Number: Int, CustomStringConvertible { // 각 case별로 숫자를 각각 넣지 않고, 맨 앞의 case에 해당하는 숫자만 rawValue에 할당하면, 그 뒤의 case들은 자동으로 맨 앞 case의 rawValue에 +1된 Integer가 할당되기 때문에 enum 타입을 선택
+    enum Number: Int, CustomStringConvertible, CaseIterable { // 각 case별로 숫자를 각각 넣지 않고, 맨 앞의 case에 해당하는 숫자만 rawValue에 할당하면, 그 뒤의 case들은 자동으로 맨 앞 case의 rawValue에 +1된 Integer가 할당되기 때문에 enum 타입을 선택
         case ace = 1 ,two ,three ,four ,five ,six ,seven , eight, nine, ten, jack, queen, king
         
         var description: String {
@@ -28,7 +28,7 @@ class Card {
         }
     }
     
-    enum Symbol: Character, CustomStringConvertible { // 해당 타입에는 case별 rawValue를 갖는 것 외에 다른 메서드나 프로퍼티가 있을 필요가 없어, 가장 간단한 타입인 enum 타입을 선택
+    enum Symbol: Character, CustomStringConvertible, CaseIterable { // 해당 타입에는 case별 rawValue를 갖는 것 외에 다른 메서드나 프로퍼티가 있을 필요가 없어, 가장 간단한 타입인 enum 타입을 선택
         case heart = "\u{1F5A4}"
         case spade = "\u{2660}"
         case diamond = "\u{25C6}"

--- a/PockerGameApp/PockerGameApp/Card.swift
+++ b/PockerGameApp/PockerGameApp/Card.swift
@@ -39,8 +39,8 @@ class Card {
         }
     }
     
-    var number: Number
-    var symbol: Symbol
+    let number: Number
+    let symbol: Symbol
     
     init(number: Number, symbol: Symbol) {
         self.number = number
@@ -51,6 +51,6 @@ class Card {
 
 extension Card: CustomStringConvertible {
     var description: String {
-        return symbol.description + number.description
+        return "\(symbol)\(number)"
     }
 }

--- a/PockerGameApp/PockerGameApp/Card.swift
+++ b/PockerGameApp/PockerGameApp/Card.swift
@@ -54,3 +54,15 @@ extension Card: CustomStringConvertible {
         return "\(symbol)\(number)"
     }
 }
+
+extension Card: Equatable {
+    static func == (lhs: Card, rhs: Card) -> Bool {
+        if lhs.number == rhs.number && lhs.symbol == rhs.symbol {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    
+}

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -30,6 +30,11 @@ struct CardDeck {
         self.originDeck = deck
     }
     
+    init(_ cardArray: [Card]) {
+        self.deck = cardArray
+        self.originDeck = cardArray
+    }
+    
     public mutating func shuffle() { // Knuth Shuffle 로직 사용하여 구현
         let count = self.count
         
@@ -50,5 +55,12 @@ struct CardDeck {
     
     public mutating func reset() {
         self.deck = self.originDeck
+    }
+}
+
+extension CardDeck: Equatable {
+    static func == (lhs: CardDeck, rhs: CardDeck) -> Bool {
+        if lhs.deck == rhs.deck { return true }
+        else { return false }
     }
 }

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -1,0 +1,54 @@
+//
+//  CardDeck.swift
+//  PockerGameApp
+//
+//  Created by 김한솔 on 2022/02/22.
+//
+
+import Foundation
+
+struct CardDeck {
+    
+    private var deck: [Card]
+    private let originDeck: [Card]
+    public var count: Int {
+        return self.deck.count
+    }
+    
+    init() {
+        let allNumberCases = Card.Number.allCases
+        let allSymbolCases = Card.Symbol.allCases
+        var deck = [Card]()
+        
+        for numberCase in allNumberCases {
+            for symbolCase in allSymbolCases {
+                deck.append(Card(number: numberCase, symbol: symbolCase))
+            }
+        }
+        
+        self.deck = deck
+        self.originDeck = deck
+    }
+    
+    public mutating func shuffle() { // Knuth Shuffle 로직 사용하여 구현
+        let count = self.count
+        
+        for indexToSwap1 in 0..<count-1 {
+            let indexToSwap2 = Int.random(in: indexToSwap1..<count)
+            let tempCard = self.deck[indexToSwap1]
+            self.deck[indexToSwap1] = self.deck[indexToSwap2]
+            self.deck[indexToSwap2] = tempCard
+        }
+    }
+    
+    public mutating func removeOne() -> Card? {
+        if self.deck.isEmpty { return nil }
+        else {
+            return self.deck.removeLast()
+        }
+    }
+    
+    public mutating func reset() {
+        self.deck = self.originDeck
+    }
+}

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -59,8 +59,4 @@ struct CardDeck {
 }
 
 extension CardDeck: Equatable {
-    static func == (lhs: CardDeck, rhs: CardDeck) -> Bool {
-        if lhs.deck == rhs.deck { return true }
-        else { return false }
-    }
 }

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -57,10 +57,3 @@ struct CardDeck {
         self.deck = self.originDeck
     }
 }
-
-extension CardDeck: Equatable {
-    static func == (lhs: CardDeck, rhs: CardDeck) -> Bool {
-        if lhs.deck == rhs.deck { return true }
-        else { return false }
-    }
-}

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -57,3 +57,10 @@ struct CardDeck {
         self.deck = self.originDeck
     }
 }
+
+extension CardDeck: Equatable {
+    static func == (lhs: CardDeck, rhs: CardDeck) -> Bool {
+        if lhs.deck == rhs.deck { return true }
+        else { return false }
+    }
+}

--- a/PockerGameApp/PockerGameApp/ViewController.swift
+++ b/PockerGameApp/PockerGameApp/ViewController.swift
@@ -36,7 +36,7 @@ class ViewController: UIViewController {
     }
     
     func printDescription(of target: CustomStringConvertible) {
-        print(target.description)
+        print(target)
     }
 
 }

--- a/PockerGameApp/PockerGameAppTests/PockerGameAppTests.swift
+++ b/PockerGameApp/PockerGameAppTests/PockerGameAppTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+@testable import PockerGameApp
 
 class PockerGameAppTests: XCTestCase {
 
@@ -13,4 +14,32 @@ class PockerGameAppTests: XCTestCase {
         
     }
 
+    func initializeCardDeckTest() {
+        var cardArrayMustBeEqual = [Card]()
+        
+        for numberCase in Card.Number.allCases {
+            for symbolCase in Card.Symbol.allCases {
+                cardArrayMustBeEqual.append(Card(number: numberCase, symbol: symbolCase))
+            }
+        }
+        
+        XCTAssertEqual(CardDeck.init(), CardDeck.init(cardArrayMustBeEqual), "초기화된 값이 일치하지 않습니다.")
+    }
+    
+    func shuffleCardDeckTest() {
+        let testCardDeck1 = CardDeck()
+        var testCardDeck2 = CardDeck()
+        
+        testCardDeck2.shuffle()
+        
+        XCTAssertNotEqual(testCardDeck1, testCardDeck2, "셔플되지 않았습니다.")
+    }
+    
+    func removeCardDeckTest() {
+        var testCardDeck = CardDeck()
+        let previousCardsCount = testCardDeck.count
+        print(testCardDeck.removeOne()!)
+        
+        XCTAssertEqual(testCardDeck.count, previousCardsCount - 1, "한 장이 뽑혀 제거되지 않았습니다.")
+    }
 }

--- a/PockerGameApp/PockerGameAppTests/PockerGameAppTests.swift
+++ b/PockerGameApp/PockerGameAppTests/PockerGameAppTests.swift
@@ -1,0 +1,16 @@
+//
+//  PockerGameAppTests.swift
+//  PockerGameAppTests
+//
+//  Created by 김한솔 on 2022/02/22.
+//
+
+import XCTest
+
+class PockerGameAppTests: XCTestCase {
+
+    func testScenario() throws {
+        
+    }
+
+}

--- a/README.md
+++ b/README.md
@@ -158,3 +158,199 @@
 2. 여기서 자주 사용되는 `50`이나 숫자값들을 의미있는 코드로 표현해보세요. 숫자만 보면 이게 어떤 의미인지 알 수 없으니 상수로 선언해서 어떤 의미인지 표현해주는 게 좋습니다.
 
 	50을 `cardWidth`, 50*1.27을 `cardHeight`, 47을 `spacingFromTop` 상수로 선언하여 사용하도록 수정했습니다.
+
+
+
+---
+
+---
+
+## 2. 카드 클래스 구현하기
+
+### 📌체크 리스트
+
+- [x] 카드의 숫자, 모양을 프로퍼티로 갖는 `Card` 클래스 생성
+	- [x] 카드 정보를 출력하기 위한 문자열을 출력하는 메서드를 포함한다.
+- [x] ViewController에서 특정한 카드 객체 인스턴스를 만들어 콘솔에 출력한다.
+	- [x] 데이터를 처리하는 코드와 출력하는 코드를 분리한다.
+- [x] 앱 아이콘을 추가해본다.
+
+
+
+---
+
+### 💻진행 과정
+
+1. 카드의 정보를 프로퍼티로 갖는 Card 클래스를 선언했습니다. 카드의 숫자를 **number** 프로퍼티에, 기호 모양을 **symbol** 프로퍼티에 갖도록 했습니다.
+
+	```swift
+	class Card {
+	    
+	    enum Number: Int {
+	        case ace = 1 ,two ,three ,four ,five ,six ,seven , eight, nine, ten, jack, queen, king
+	    }
+	    
+	    enum Symbol: Character {
+	        case heart = "❤️"
+	        case spade = "♠️"
+	        case diamond = "🔷"
+	        case club = "♣️"
+	    }
+	    
+	    var number: Number
+	    var symbol: Symbol
+	    
+	    init(number: Number, symbol: Symbol) {
+	        self.number = number
+	        self.symbol = symbol
+	    }
+	    
+	    func makeDescription() -> String {
+	        var numberValue: String
+	        switch self.number.rawValue {
+	        case 1:
+	            numberValue = "A"
+	        case 11:
+	            numberValue = "J"
+	        case 12:
+	            numberValue = "Q"
+	        case 13:
+	            numberValue = "K"
+	        default:
+	            numberValue = String(number.rawValue)
+	            
+	        }
+	        return "모양: \(symbol.rawValue), 숫자: \(numberValue)"
+	    }
+	}
+	```
+
+	number의 타입에 해당하는 Number을 enum 타입으로 선언했습니다. number가 될 수 있는 케이스가 13가지인데, 해당 케이스 별로 직접 rawValue를 지정해주지 않아도 되며, number가 가질 수 있는 케이스를 제한할 수도 있기 때문에 해당 타입으로 선언했습니다. 
+
+	symbol의 타입에 해당하는 Symbol 또한 enum 타입으로 선언했습니다. Symbol 타입은 케이스 별로 rawValue를 갖는 것 외에는 다른 메서드나 연산 프로퍼티를 가질 필요가 없다고 판단하여, 가장 간단한 타입인 enum 타입으로 선언했습니다.
+
+2. 이전에 공부했던, 앱의 아이콘을 만드는 방법을 다시 공부할 겸 앱의 아이콘을 만들어 추가했습니다. 추가한 앱의 아이콘은 아래와 같이 확인할 수 있습니다.
+
+	<img src="https://user-images.githubusercontent.com/92504186/154935762-971b3380-3fbd-4533-ae73-ee31a9de4d01.jpg" alt="SS 2022-02-21 PM 07 10 21" width="10%;" />
+
+3. ViewController 클래스에 아래의 코드를 추가하여, 임의의 카드 인스턴스를 생성해 출력했습니다.
+
+	```swift
+	// class ViewController: UIViewController
+	override func viewDidLoad() {
+	    ...
+	    let newCard = Card(number: .ace, symbol: .spade)
+	    printCardDescription(newCard)
+	}
+	
+	func printCardDescription(_ card: Card) {
+	    print(card.makeDescription())
+	}
+	```
+
+	<img src="https://user-images.githubusercontent.com/92504186/154937843-8110c182-7aa3-405c-960e-9145185d063a.jpg" alt="SS 2022-02-21 PM 06 57 34" width="30%;" />
+
+
+
+---
+
+### 🤔코드리뷰 후 추가 수정사항
+
+1. description을 처리하는 것을 지원하는 CustomStringConvertible 프로토콜을 학습해보세요
+
+	```swift
+	protocol CustomStringConvertible
+	```
+
+	> A type with a customized textual representation.
+	>
+	> 텍스트적인 표현을 커스터마이즈해주는 타입
+
+	해당 프로토콜을 채택하지 않은 구조체를 Print하면 아래와 같이 출력됩니다.
+
+	```swift
+	struct Milk {
+	    var title: String = ""
+	    var amount: Int = 0
+	    var type: MilkType = .Choco
+	}
+	
+	print(Milk()) // Prints "Milk(title: "", amount: 0, type: MilkType.Choco)"
+	```
+
+	 Milk 구조체가 `CustomStringConvertible` 프로토콜을 채택하여 `description` 프로퍼티를 지정해주면 원하는 형태로 출력할 수 있습니다.
+
+	```swift
+	extension Milk: CustomStringConvertible {
+	    var description: String {
+	        return self.type.rawValue + self.amount + "우유"
+	    }
+	}
+	
+	print(Milk(amount: 150)) // Prints "Choco150우유"
+	```
+
+	---
+
+	위의 `CustomStringConvertible` 프로토콜을 채택하여 수정한 Card클래스는 아래와 같습니다.
+
+	```swift
+	class Card {
+	    
+	    enum Number: Int, CustomStringConvertible {
+	        case ace = 1 ,two ,three ,four ,five ,six ,seven , eight, nine, ten, jack, queen, king
+	        
+	        var description: String {
+	            switch self.rawValue {
+	            case 1:
+	                return("A")
+	            case 11:
+	                return("J")
+	            case 12:
+	                return("Q")
+	            case 13:
+	                return("K")
+	            default:
+	                return(String(self.rawValue))
+	            }
+	        }
+	    }
+	    
+	    enum Symbol: Character, CustomStringConvertible {
+	        case heart = "❤️"
+	        case spade = "♠️"
+	        case diamond = "🔷"
+	        case club = "♣️"
+	        
+	        var description: String {
+	            return String(self.rawValue)
+	        }
+	    }
+	    
+	    var number: Number
+	    var symbol: Symbol
+	    
+	    init(number: Number, symbol: Symbol) {
+	        self.number = number
+	        self.symbol = symbol
+	    }
+	
+	}
+	
+	extension Card: CustomStringConvertible {
+	    var description: String {
+	        return symbol.description + number.description
+	    }
+	}
+	```
+
+2. self.view.addSubview()로도 추가를 하는데 cards.append()를 다시 하는 이유가 뭘까요? 안해도 상관없지 않을까요?
+
+	처음 생각으로는, 나중에 각각의 카드 UIImageView의 Image 프로퍼티를 수정해주게 될 것이라 생각해서, 모든 UIImageView들을 하나의 배열에 담아놨었습니다. 하지만 self.view에 subView로 이미 추가해놨기 때문에, self.view.subviews 배열을 이용하면 해당 UIImageView에 접근할 수 있게 됩니다. 따라서 cards 배열을 삭제했습니다.
+
+
+
+---
+
+---
+


### PR DESCRIPTION
# 02-3) 카드덱 구현하기 + 테스트
## 작업 목록
- [x] CardDeck 구조체 구현
  - [x] 접근제어 구문 활용하여, 내부 속성을 모두 감추고 count프로퍼티와 shuffle, removeOne, reset 메서드만 외부에서 접근할 수 있도록 설정
  - [x] shuffle 메서드를 Knuth Shuffle 로직을 이용해 구현
- [x] 테스트 작성
## 학습 키워드
`CaseIterable` , `Knuth Shuffle` , `Equatable`, `UnitTest` , `XCTAssert`
## 고민과 해결
- Card 클래스의 Symbol, Number 열거형들의 모든 케이스를 이용해 인스턴스를 생성할 때 모든 케이스들을 직접 작성해서 집어넣는 방법밖에 생각나지 않아 고민만 하고 있었는데, 다른 팀원(싱하)의 PR을 살펴보던 중 `CaseIterable`  이라는 프로토콜에 대해 알게 되었고 코드에 추가하여 열거형의 모든 케이스를 코드 한줄로 배열로 만들어주어서 사용할 수 있었습니다.
- 강의자료에 있는 유튜브 강의를 듣다가 구조체의 경우에는 Equality만 비교할 수 있다는 내용을 잘못 해석해서, Equatable 프로토콜을 채택하지 않아도 값비교는 무조건 가능하다고 생각하여 해당 프로토콜을 지워봤는데 Euality 비교가 안됐었습니다. 그래서 다시 Equatble 프로토콜을 채택해봤는데, `==(_:_:)` 메서드를 선언하지 않아도 비교가 가능하다는 사실을 발견했고, [해당 페이지](https://stackoverflow.com/questions/37541512/swift-struct-doesnt-conform-to-protocol-equatable)를 보고, 구조체의 모든 프로퍼티가 Equatable을 채택한 타입이라면 `==(_:_:)` 메서드가 필요없다는걸 알 수 있었습니다.