### PR TITLE
[Jed] Step 2-3 : 카드덱 구현하고 테스트하기

### DIFF
--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		B56CA14B27C3234F001DC373 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B56CA14A27C3234F001DC373 /* Assets.xcassets */; };
 		B56CA14E27C3234F001DC373 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B56CA14C27C3234F001DC373 /* LaunchScreen.storyboard */; };
 		B56CA15827C486FA001DC373 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56CA15727C486FA001DC373 /* Card.swift */; };
+		B56CA15A27C4B688001DC373 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56CA15927C4B688001DC373 /* CardDeck.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		B56CA14D27C3234F001DC373 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		B56CA14F27C3234F001DC373 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B56CA15727C486FA001DC373 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+		B56CA15927C4B688001DC373 /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +61,7 @@
 			isa = PBXGroup;
 			children = (
 				B56CA15727C486FA001DC373 /* Card.swift */,
+				B56CA15927C4B688001DC373 /* CardDeck.swift */,
 				B56CA14127C3234D001DC373 /* AppDelegate.swift */,
 				B56CA14327C3234D001DC373 /* SceneDelegate.swift */,
 				B56CA14527C3234D001DC373 /* ViewController.swift */,
@@ -142,6 +145,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B56CA15827C486FA001DC373 /* Card.swift in Sources */,
+				B56CA15A27C4B688001DC373 /* CardDeck.swift in Sources */,
 				B56CA14627C3234D001DC373 /* ViewController.swift in Sources */,
 				B56CA14227C3234D001DC373 /* AppDelegate.swift in Sources */,
 				B56CA14427C3234D001DC373 /* SceneDelegate.swift in Sources */,

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -1,11 +1,7 @@
 import Foundation
 
 class Card: CustomStringConvertible{
-    
-    /*
-     카드 모양은 4가지만 존재하기 때문에 열거형으로 각 케이스를 선언했습니다.
-     굳이 클래스나 구조체로 만들 필요 없이 각 케이스별로 일정한 문자열값을 보여주면 된다고 생각했습니다.
-     */
+
     internal enum Suit: CustomStringConvertible, CaseIterable{
         case clover
         case diamond
@@ -25,12 +21,7 @@ class Card: CustomStringConvertible{
             }
         }
     }
-    
-    /*
-     카드 숫자는 실제 숫자와 출력을 위한 문자의 두 가지 속성을 가진 구조체로 선언했습니다.
-     실제 정수타입의 숫자값과 출력을 위한 문자열값을 모두 가지고 있어야 한다고 생각했고,
-     열거형으로 13가지의 케이스를 모두 선언하기 보다는 구조체의 description 프로퍼티값을 switch를 통해 각기 다른 값을 가지도록 하는 것이 더 효율적이라고 생각했습니다.
-     */
+
     internal enum Number:String, CustomStringConvertible, CaseIterable{
         
         case ace = "A"

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -31,23 +31,24 @@ class Card: CustomStringConvertible{
      실제 정수타입의 숫자값과 출력을 위한 문자열값을 모두 가지고 있어야 한다고 생각했고,
      열거형으로 13가지의 케이스를 모두 선언하기 보다는 구조체의 description 프로퍼티값을 switch를 통해 각기 다른 값을 가지도록 하는 것이 더 효율적이라고 생각했습니다.
      */
-    internal struct Number: CustomStringConvertible{
-        var number: Int
-        var description: String{
-            switch number{
-            case 11:
-                return "A"
-            case 12:
-                return "Q"
-            case 13:
-                return "K"
-            default:
-                return String(number)
-            }
-        }
+    internal enum Number:String, CustomStringConvertible, CaseIterable{
         
-        init(_ number: Int){
-            self.number = number
+        case ace = "A"
+        case two = "2"
+        case three = "3"
+        case four = "4"
+        case five = "5"
+        case six = "6"
+        case seven = "7"
+        case eight = "8"
+        case nine = "9"
+        case ten = "10"
+        case jump = "J"
+        case queen = "Q"
+        case king = "K"
+        
+        var description: String{
+            return self.rawValue
         }
     }
     

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -57,11 +57,11 @@ class Card: CustomStringConvertible{
         return "\(suit)\(number)"
     }
     
-    init?(cardSuitindex: Int, cardNumber: Int){
-        if(cardSuitindex>=Suit.allCases.count || cardNumber<=0 || cardNumber > 13){
+    init?(suitIndex: Int, number: Int){
+        if(suitIndex>=Suit.allCases.count || number<=0 || number > 13){
             return nil
         }
-        self.suit = Suit.allCases[cardSuitindex]
-        self.number = Number(cardNumber)
+        self.suit = Suit.allCases[suitIndex]
+        self.number = Number(number)
     }
 }

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -51,17 +51,14 @@ class Card: CustomStringConvertible{
         }
     }
     
-    var suit: Suit
-    var number: Number
+    let suit: Suit
+    let number: Number
     var description: String{
         return "\(suit)\(number)"
     }
     
-    init?(suitIndex: Int, number: Int){
-        if(suitIndex>=Suit.allCases.count || number<=0 || number > 13){
-            return nil
-        }
-        self.suit = Suit.allCases[suitIndex]
-        self.number = Number(number)
+    init?(suit: Suit, number: Number){
+        self.suit = suit
+        self.number = number
     }
 }

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -49,7 +49,7 @@ class Card: CustomStringConvertible{
         return "\(suit)\(number)"
     }
     
-    init?(suit: Suit, number: Number){
+    init(suit: Suit, number: Number){
         self.suit = suit
         self.number = number
     }

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -6,7 +6,7 @@ class Card: CustomStringConvertible{
      카드 모양은 4가지만 존재하기 때문에 열거형으로 각 케이스를 선언했습니다.
      굳이 클래스나 구조체로 만들 필요 없이 각 케이스별로 일정한 문자열값을 보여주면 된다고 생각했습니다.
      */
-    internal enum CardSuit: CustomStringConvertible, CaseIterable{
+    internal enum Suit: CustomStringConvertible, CaseIterable{
         case clover
         case diamond
         case club
@@ -31,7 +31,7 @@ class Card: CustomStringConvertible{
      실제 정수타입의 숫자값과 출력을 위한 문자열값을 모두 가지고 있어야 한다고 생각했고,
      열거형으로 13가지의 케이스를 모두 선언하기 보다는 구조체의 description 프로퍼티값을 switch를 통해 각기 다른 값을 가지도록 하는 것이 더 효율적이라고 생각했습니다.
      */
-    internal struct CardNumber: CustomStringConvertible{
+    internal struct Number: CustomStringConvertible{
         var number: Int
         var description: String{
             switch number{
@@ -51,17 +51,17 @@ class Card: CustomStringConvertible{
         }
     }
     
-    var suit: CardSuit
-    var number: CardNumber
+    var suit: Suit
+    var number: Number
     var description: String{
         return "\(suit)\(number)"
     }
     
     init?(cardSuitindex: Int, cardNumber: Int){
-        if(cardSuitindex>=CardSuit.allCases.count || cardNumber<=0 || cardNumber > 13){
+        if(cardSuitindex>=Suit.allCases.count || cardNumber<=0 || cardNumber > 13){
             return nil
         }
-        self.suit = CardSuit.allCases[cardSuitindex]
-        self.number = CardNumber(cardNumber)
+        self.suit = Suit.allCases[cardSuitindex]
+        self.number = Number(cardNumber)
     }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -28,7 +28,7 @@ struct CardDeck{
         self.deck = []
         for suit in Card.Suit.allCases{
             for number in Card.Number.allCases{
-                guard let card = Card(suit: suit, number: number) else{ continue }
+                let card = Card(suit: suit, number: number)
                 self.deck.append(card)
             }
         }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -12,10 +12,10 @@ struct CardDeck{
     }
     
     mutating func shuffle(){
-        for i in 0..<deck.count-1{
-            let randomIndex = Int.random(in: i..<deck.count)
-            let temp = deck[i]
-            deck[i] = deck[randomIndex]
+        for startIndex in 0..<deck.count-1{
+            let randomIndex = Int.random(in: startIndex..<deck.count)
+            let temp = deck[startIndex]
+            deck[startIndex] = deck[randomIndex]
             deck[randomIndex] = temp
         }
     }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -3,7 +3,9 @@ import Foundation
 struct CardDeck{
     
     private var deck: [Card] = []
-    private (set) var count: Int = 0
+    var count: Int{
+        return deck.count
+    }
     
     init(){
         reset()
@@ -19,7 +21,6 @@ struct CardDeck{
     }
     
     mutating func removeOne()-> Card{
-        count -= 1
         return deck.removeLast()
     }
     
@@ -31,6 +32,5 @@ struct CardDeck{
                 self.deck.append(card)
             }
         }
-        self.count = self.deck.count
     }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct CardDeck{
+    
+    var count: Int
+    
+    func shuffle(){
+        
+    }
+    
+    func removeOne(){
+        
+    }
+    
+    func reset(){
+        
+    }
+}

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -10,7 +10,12 @@ struct CardDeck{
     }
     
     mutating func shuffle(){
-        
+        for i in 0..<deck.count-1{
+            let randomIndex = Int.random(in: i..<deck.count)
+            let temp = deck[i]
+            deck[i] = deck[randomIndex]
+            deck[randomIndex] = temp
+        }
     }
     
     mutating func removeOne()-> Card{
@@ -27,6 +32,5 @@ struct CardDeck{
             }
         }
         self.count = self.deck.count
-        shuffle()
     }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -20,8 +20,8 @@ struct CardDeck{
         }
     }
     
-    mutating func removeOne()-> Card{
-        return deck.removeLast()
+    mutating func removeOne()-> Card?{
+        return deck.popLast()
     }
     
     mutating func reset(){

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -2,17 +2,31 @@ import Foundation
 
 struct CardDeck{
     
-    var count: Int
+    private var deck: [Card] = []
+    private (set) var count: Int = 0
     
-    func shuffle(){
+    init(){
+        reset()
+    }
+    
+    mutating func shuffle(){
         
     }
     
-    func removeOne(){
-        
+    mutating func removeOne()-> Card{
+        count -= 1
+        return deck.removeLast()
     }
     
-    func reset(){
-        
+    mutating func reset(){
+        self.deck = []
+        for suit in Card.Suit.allCases{
+            for number in Card.Number.allCases{
+                guard let card = Card(suit: suit, number: number) else{ continue }
+                self.deck.append(card)
+            }
+        }
+        self.count = self.deck.count
+        shuffle()
     }
 }

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -35,9 +35,9 @@ class ViewController: UIViewController {
     }
     
     func testCardPrinting(){
-        for cardNumber in 1...13{
-            let randomIndex = Int.random(in: 0...3)
-            if let card = Card(suit: Card.Suit.allCases[randomIndex], number: Card.Number(cardNumber)){
+        for cardNumberIndex in 0..<12{
+            let cardSuitIndex = Int.random(in: 0...3)
+            if let card = Card(suit: Card.Suit.allCases[cardSuitIndex], number: Card.Number.allCases[cardNumberIndex]){
                 printCard(card)
             }
         }

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -6,7 +6,7 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         setBackgroundColor()
         setInitialImageView(7)
-        //testCardPrinting()
+        testCardPrinting()
         testCardDeckCreation()
     }
     
@@ -36,9 +36,9 @@ class ViewController: UIViewController {
     }
     
     func testCardPrinting(){
-        for cardNumberIndex in 0..<12{
-            let cardSuitIndex = Int.random(in: 0...3)
-            let card = Card(suit: Card.Suit.allCases[cardSuitIndex], number: Card.Number.allCases[cardNumberIndex])
+        for _ in 0..<7{
+            guard let suit = Card.Suit.allCases.randomElement(), let number = Card.Number.allCases.randomElement() else { return }
+            let card = Card(suit: suit, number: number)
             printCard(card)
         }
     }

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -60,7 +60,8 @@ class ViewController: UIViewController {
                 deck.shuffle()
                 print("전체 \(deck.count)장의 카드를 섞었습니다.")
             case "remove":
-                print("\(deck.removeOne())\n총 \(deck.count)장의 카드가 남아있습니다.")
+                guard let removedCard = deck.removeOne() else { continue }
+                print("\(removedCard)\n총 \(deck.count)장의 카드가 남아있습니다.")
             default:
                 print("테스트 종료")
                 break

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -38,9 +38,8 @@ class ViewController: UIViewController {
     func testCardPrinting(){
         for cardNumberIndex in 0..<12{
             let cardSuitIndex = Int.random(in: 0...3)
-            if let card = Card(suit: Card.Suit.allCases[cardSuitIndex], number: Card.Number.allCases[cardNumberIndex]){
-                printCard(card)
-            }
+            let card = Card(suit: Card.Suit.allCases[cardSuitIndex], number: Card.Number.allCases[cardNumberIndex])
+            printCard(card)
         }
     }
     

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -6,7 +6,8 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         setBackgroundColor()
         setInitialImageView(7)
-        testCardPrinting()
+        //testCardPrinting()
+        testCardDeckCreation()
     }
     
     func setBackgroundColor(){
@@ -45,6 +46,27 @@ class ViewController: UIViewController {
     
     func printCard(_ card: Card){
         print(card)
+    }
+    
+    func testCardDeckCreation(){
+        var deck: CardDeck = CardDeck()
+        let commands: [String] = ["reset","shuffle","remove","remove","shuffle","reset","remove","shuffle","remove","exit"]
+        for command in commands{
+            print(command)
+            switch command{
+            case "reset":
+                deck.reset()
+                print("카드 전체를 초기화했습니다.\n총 \(deck.count)장의 카드가 있습니다.")
+            case "shuffle":
+                deck.shuffle()
+                print("전체 \(deck.count)장의 카드를 섞었습니다.")
+            case "remove":
+                print("\(deck.removeOne())\n총 \(deck.count)장의 카드가 남아있습니다.")
+            default:
+                print("테스트 종료")
+                break
+            }
+        }
     }
 }
 

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -37,7 +37,7 @@ class ViewController: UIViewController {
     func testCardPrinting(){
         for cardNumber in 1...13{
             let randomIndex = Int.random(in: 0...3)
-            if let card = Card(suitIndex: randomIndex, number: cardNumber){
+            if let card = Card(suit: Card.Suit.allCases[randomIndex], number: Card.Number(cardNumber)){
                 printCard(card)
             }
         }

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -37,7 +37,7 @@ class ViewController: UIViewController {
     func testCardPrinting(){
         for cardNumber in 1...13{
             let randomIndex = Int.random(in: 0...3)
-            if let card = Card(cardSuitindex: randomIndex, cardNumber: cardNumber){
+            if let card = Card(suitIndex: randomIndex, number: cardNumber){
                 printCard(card)
             }
         }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 - [x] 게임 보드 만들기(2021.02.21 19:26)
 - [x] 카드 클래스 구현하기
-- [ ] 카드덱 구현하고 테스트하기
+- [x] 카드덱 구현하고 테스트하기
 - [ ] 게임로직 구현하기
 - [ ] 포커게임 화면 만들기
 - [ ] 승자 표시하기
@@ -97,3 +97,79 @@ class Card: CustomStringConvertible{
 ```
 
 ​    
+
+## 3. 카드 덱 구현하고 테스트하기
+
+- CardDeck 구조체는 내부에 카드 배열인 deck과 배열의 크기(카드의 개수)에 해당하는 count를 프로퍼티로 가짐
+- 요구조건에 따라 외부에서는 count만 읽도록 해야 하므로 deck은 get,set 모두 private로 선언했으며, count는 set만 private로 선언
+
+```swift
+private var deck: [Card] = []
+private (set) var count: Int = 0
+```
+
+- reset()은 전체 카드 52장을 순차적으로 배열에 넣는 동작을 실행
+
+```swift
+mutating func reset(){
+  self.deck = []
+  for suit in Card.Suit.allCases{
+    for number in Card.Number.allCases{
+      guard let card = Card(suit: suit, number: number) else{ continue }
+      self.deck.append(card)
+    }
+  }
+  self.count = self.deck.count
+}
+```
+
+- shuffle()은 Knuth Shuffle방식을 적용하여 배열 내의 각 카드의 순서를 무작위로 섞어줌
+
+```swift
+mutating func shuffle(){
+  for i in 0..<deck.count-1{
+    let randomIndex = Int.random(in: i..<deck.count)
+    let temp = deck[i]
+    deck[i] = deck[randomIndex]
+    deck[randomIndex] = temp
+  }
+}
+```
+
+- removeOne()은 카드를 덱에서 한 장씩 뽑기 위해, 배열의 맨 마지막 요소부터 제거하는 동작을 수행
+  - 배열의 처음부터 제거하면 나머지 요소의 인덱스를 재조정해야 하므로 성능상 더 비효율적임
+
+```swift
+mutating func removeOne()-> Card{
+  count -= 1
+  return deck.removeLast()
+}
+```
+
+- ViewController에 카드 덱의 생성 및 섞는 과정을 테스트하기 위한 메소드 추가
+
+```swift
+  func testCardDeckCreation(){
+  var deck: CardDeck = CardDeck()
+  let commands: [String] =["reset","shuffle","remove","remove","shuffle","reset","remove","shuffle","remove","exit"]
+  for command in commands{
+    print(command)
+    switch command{
+      case "reset":
+      deck.reset()
+      print("카드 전체를 초기화했습니다.\n총 \(deck.count)장의 카드가 있습니다.")
+      case "shuffle":
+      deck.shuffle()
+      print("전체 \(deck.count)장의 카드를 섞었습니다.")
+      case "remove":
+      print("\(deck.removeOne())\n총 \(deck.count)장의 카드가 남아있습니다.")
+      default:
+      print("테스트 종료")
+      break
+    }
+  }
+}
+```
+
+
+


### PR DESCRIPTION
## 작업 내용
- [x] 기존 2단계 피드백 반영하여 Card 클래스 수정
- [x] 카드덱 구조체 구현
    - [x] count, shuffle, removeOne, reset 각각 구현
    - [x] 상위모듈에서 카드덱 기능 확인을 위한 테스트 메소드 작성    
 
## 학습 키워드
- mutating
- CaseIterable, allCases
- Knuth Shuffle

## 고민과 해결
- 기존 2단계 피드백을 반영해서 Card 내부의 Number 타입을 Enum으로 수정하였고, Card의 파라미터 타입을 Int가 아닌 각각 Suit, Number로 받도록 했습니다.
    
- CardDeck 구조체의 프로퍼티로 deck, count 두 개를 가지고 있는데, 외부에서 deck에는 직접 접근하지 못해야 하고 count는 읽기만 가능해야 하기 때문에 접근제어자를 아래와 같이 선언했습니다.
```swift
 private var deck: [Card] = []
 private (set) var count: Int = 0
```
- 여기서 덱에 카드를 넣는 동작은 reset()에서 실행하도록 하고, 생성자 호출 시 reset()을 호출하도록 했습니다.
    - 이 경우 생성자에서 기존 프로퍼티 값을 바꾸는 메소드를 호출하기 위해서는 stored property의 값이 이미 초기화된 상태여야하기 때문에 위와 같이 프로퍼티 선언 시에 각각 빈 배열과 0의 값을 가지도록 했습니다. 
- 덱에서 카드를 빼는 동작은 배열의 removeLast() 메소드를 내부적으로 호출하도록 했습니다.
    - removeFirst()로 할 경우에는 배열의 맨 처음 요소를 제거하면서 나머지 요소들의 인덱스를 한칸씩 앞으로 빼는 연산을 수행해야 하므로 비효율적일 것이라 판단했습니다. 
```swift
mutating func removeOne()-> Card{
   count -= 1
   return deck.removeLast()
}
``` 