### PR TITLE
[Eddy] Step 3: CardDeck 객체 구현 

### DIFF
--- a/PockerGameApp/PockerGameApp/Card.swift
+++ b/PockerGameApp/PockerGameApp/Card.swift
@@ -25,7 +25,7 @@ struct Card: CustomStringConvertible {
 // Card 객체보다, CardSuit & CardNumber 객체와 관련성이 더 높다고 판단해 해당 객체에 추가했습니다.
 // Enum과 CustomStringCovertible를 사용했습니다.
 
-enum CardSuit: CustomStringConvertible {
+enum CardSuit: CustomStringConvertible, CaseIterable {
     case spades
     case clubs
     case hearts
@@ -48,7 +48,7 @@ enum CardSuit: CustomStringConvertible {
 // 각 CardNumber가 가지는 숫자값은 RawValue(Int)로 담아주었습니다.
 // 이후 RawValue로 enum을 생성하거나, 게임 로직에서 rawValue를 호출하여 사용할 수 있을 거 같습니다.
 
-enum CardNumber: Int, CustomStringConvertible {
+enum CardNumber: Int, CustomStringConvertible, CaseIterable {
     case ace = 1
     case two = 2
     case three = 3

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -33,8 +33,8 @@ struct CardDeck {
         }
     }
     
-    mutating func draw() -> Card {
-        return cards.removeLast()
+    mutating func draw() -> Card? {
+        return cards.popLast()
     }
     
     mutating func reset() {

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct CardDeck {
-    private var cards: [Card]
+    var cards: [Card]
     
     init() {
         var cards = [Card]()

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -26,15 +26,11 @@ struct CardDeck {
     }
     
     mutating func shuffle() {
-        // Fisher–Yates shuffle
-        var cards = self.cards
-        var shuffled = [Card]()
-        
-        while !cards.isEmpty {
+        // Mordern Fisher-Yates Shuffle (in-place)
+        for i in 0..<cards.count-1 {
             let roll = Int.random(in: 0..<cards.count)
-            shuffled.append(cards.remove(at: roll))
+            cards.swapAt(i, roll)
         }
-        self.cards = shuffled
     }
     
     func removeOne() {

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct CardDeck {
     private var cards: [Card]
+    private var defaultCards: [Card]
     
     public init() {
         var cards = [Card]()
@@ -17,7 +18,8 @@ struct CardDeck {
                 cards.append(Card(suit: suit, number: number))
             }
         }
-        self.cards = cards
+        self.defaultCards = cards
+        self.cards = defaultCards
         shuffle()
     }
     
@@ -38,13 +40,7 @@ struct CardDeck {
     }
     
     public mutating func reset() {
-        var cards = [Card]()
-        for suit in CardSuit.allCases {
-            for number in CardNumber.allCases {
-                cards.append(Card(suit: suit, number: number))
-            }
-        }
-        self.cards = cards
+        self.cards = defaultCards
         shuffle()
     }
 }

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -1,0 +1,32 @@
+//
+//  CardDeck.swift
+//  PokerGameApp
+//
+//  Created by Bumgeun Song on 2022/02/22.
+//
+
+import Foundation
+
+struct CardDeck {
+    private var cards: [Card]
+    
+    init() {
+        
+    }
+    
+    var count: Int {
+        return cards.count
+    }
+    
+    func shuffle() {
+        
+    }
+    
+    func removeOne() {
+        
+    }
+    
+    func reset() {
+        
+    }
+}

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct CardDeck {
-    var cards: [Card]
+    private var cards: [Card]
     
     init() {
         var cards = [Card]()
@@ -37,7 +37,22 @@ struct CardDeck {
         return cards.removeLast()
     }
     
-    func reset() {
-        
+    mutating func reset() {
+        var cards = [Card]()
+        for suit in CardSuit.allCases {
+            for number in CardNumber.allCases {
+                cards.append(Card(suit: suit, number: number))
+            }
+        }
+        self.cards = cards
+        shuffle()
+    }
+}
+
+extension CardDeck: CustomStringConvertible {
+    var description: String {
+        return cards.reduce("") { partialResult, card in
+            "\(partialResult) \(card)"
+        }
     }
 }

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -11,7 +11,13 @@ struct CardDeck {
     private var cards: [Card]
     
     init() {
-        
+        var cards = [Card]()
+        for suit in CardSuit.allCases {
+            for number in CardNumber.allCases {
+                cards.append(Card(suit: suit, number: number))
+            }
+        }
+        self.cards = cards
     }
     
     var count: Int {

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -10,7 +10,7 @@ import Foundation
 struct CardDeck {
     private var cards: [Card]
     
-    init() {
+    public init() {
         var cards = [Card]()
         for suit in CardSuit.allCases {
             for number in CardNumber.allCases {
@@ -21,11 +21,11 @@ struct CardDeck {
         shuffle()
     }
     
-    var count: Int {
+    public var count: Int {
         return cards.count
     }
     
-    mutating func shuffle() {
+    public mutating func shuffle() {
         // Mordern Fisher-Yates Shuffle (in-place)
         for i in 0..<cards.count-1 {
             let roll = Int.random(in: 0..<cards.count)
@@ -33,11 +33,11 @@ struct CardDeck {
         }
     }
     
-    mutating func draw() -> Card? {
+    public mutating func draw() -> Card? {
         return cards.popLast()
     }
     
-    mutating func reset() {
+    public mutating func reset() {
         var cards = [Card]()
         for suit in CardSuit.allCases {
             for number in CardNumber.allCases {

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -18,14 +18,23 @@ struct CardDeck {
             }
         }
         self.cards = cards
+        shuffle()
     }
     
     var count: Int {
         return cards.count
     }
     
-    func shuffle() {
+    mutating func shuffle() {
+        // Fisher–Yates shuffle
+        var cards = self.cards
+        var shuffled = [Card]()
         
+        while !cards.isEmpty {
+            let roll = Int.random(in: 0..<cards.count)
+            shuffled.append(cards.remove(at: roll))
+        }
+        self.cards = shuffled
     }
     
     func removeOne() {

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -45,8 +45,6 @@ struct CardDeck {
 
 extension CardDeck: CustomStringConvertible {
     var description: String {
-        return cards.reduce("") { partialResult, card in
-            "\(partialResult) \(card)"
-        }
+        return "\(cards)"
     }
 }

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -20,7 +20,6 @@ struct CardDeck {
         }
         self.defaultCards = cards
         self.cards = defaultCards
-        shuffle()
     }
     
     public var count: Int {
@@ -41,7 +40,6 @@ struct CardDeck {
     
     public mutating func reset() {
         self.cards = defaultCards
-        shuffle()
     }
 }
 

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -33,8 +33,8 @@ struct CardDeck {
         }
     }
     
-    func removeOne() {
-        
+    mutating func draw() -> Card {
+        return cards.removeLast()
     }
     
     func reset() {

--- a/PockerGameApp/PockerGameApp/ViewController.swift
+++ b/PockerGameApp/PockerGameApp/ViewController.swift
@@ -21,16 +21,24 @@ class ViewController: UIViewController {
         print("---counts---")
         print(deck.count)
         print("---initial card---")
-        print(deck.cards)
+        print(deck)
         
         print("---shuffled---")
         deck.shuffle()
-        print(deck.cards)
+        print(deck)
         
         print("---draw---")
         print(deck.draw())
         print(deck.count)
-        print(deck.cards)
+        print(deck)
+        print(deck.draw())
+        print(deck.count)
+        print(deck)
+        
+        print("---Reset---")
+        deck.reset()
+        print(deck.count)
+        print(deck)
     }
     
     func setupBackgroundPattern() {

--- a/PockerGameApp/PockerGameApp/ViewController.swift
+++ b/PockerGameApp/PockerGameApp/ViewController.swift
@@ -13,13 +13,19 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         setupBackgroundPattern()
         setupCards()
+        testCardDeck()
+    }
+    
+    func testCardDeck() {
+        var deck = CardDeck()
+        print("---counts---")
+        print(deck.count)
+        print("---initial card---")
+        print(deck.cards)
         
-        let spades6 = Card(suit: .spades, number: .six)
-        print(spades6)
-        let heartQueen = Card(suit: .hearts, number: CardNumber(rawValue: 12)!)
-        print(heartQueen)
-        let diamondsAce = Card(suit: .diamonds, number: .ace)
-        print(diamondsAce)
+        print("---shuffled---")
+        deck.shuffle()
+        print(deck.cards)
     }
     
     func setupBackgroundPattern() {

--- a/PockerGameApp/PockerGameApp/ViewController.swift
+++ b/PockerGameApp/PockerGameApp/ViewController.swift
@@ -26,6 +26,11 @@ class ViewController: UIViewController {
         print("---shuffled---")
         deck.shuffle()
         print(deck.cards)
+        
+        print("---draw---")
+        print(deck.draw())
+        print(deck.count)
+        print(deck.cards)
     }
     
     func setupBackgroundPattern() {

--- a/PockerGameApp/PockerGameApp/ViewController.swift
+++ b/PockerGameApp/PockerGameApp/ViewController.swift
@@ -13,32 +13,6 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         setupBackgroundPattern()
         setupCards()
-        testCardDeck()
-    }
-    
-    func testCardDeck() {
-        var deck = CardDeck()
-        print("---counts---")
-        print(deck.count)
-        print("---initial card---")
-        print(deck)
-        
-        print("---shuffled---")
-        deck.shuffle()
-        print(deck)
-        
-        print("---draw---")
-        print(deck.draw())
-        print(deck.count)
-        print(deck)
-        print(deck.draw())
-        print(deck.count)
-        print(deck)
-        
-        print("---Reset---")
-        deck.reset()
-        print(deck.count)
-        print(deck)
     }
     
     func setupBackgroundPattern() {

--- a/PockerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PockerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		BC8BDC0327C38938008E38F3 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8BDC0227C38938008E38F3 /* Card.swift */; };
+		BC8BDC0727C4B525008E38F3 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8BDC0627C4B525008E38F3 /* CardDeck.swift */; };
 		BCB1A01027C32E1100D7B8FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB1A00F27C32E1100D7B8FD /* AppDelegate.swift */; };
 		BCB1A01227C32E1100D7B8FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB1A01127C32E1100D7B8FD /* SceneDelegate.swift */; };
 		BCB1A01427C32E1100D7B8FD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB1A01327C32E1100D7B8FD /* ViewController.swift */; };
@@ -19,6 +20,7 @@
 
 /* Begin PBXFileReference section */
 		BC8BDC0227C38938008E38F3 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+		BC8BDC0627C4B525008E38F3 /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
 		BCB1A00C27C32E1100D7B8FD /* PokerGameApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PokerGameApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCB1A00F27C32E1100D7B8FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BCB1A01127C32E1100D7B8FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -65,6 +67,7 @@
 				BCB1A01127C32E1100D7B8FD /* SceneDelegate.swift */,
 				BCB1A01327C32E1100D7B8FD /* ViewController.swift */,
 				BC8BDC0227C38938008E38F3 /* Card.swift */,
+				BC8BDC0627C4B525008E38F3 /* CardDeck.swift */,
 				BCB1A01527C32E1100D7B8FD /* Main.storyboard */,
 				BCB1A01827C32E1200D7B8FD /* Assets.xcassets */,
 				BCB1A01A27C32E1200D7B8FD /* LaunchScreen.storyboard */,
@@ -146,6 +149,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BCB1A01427C32E1100D7B8FD /* ViewController.swift in Sources */,
+				BC8BDC0727C4B525008E38F3 /* CardDeck.swift in Sources */,
 				BCB1A01027C32E1100D7B8FD /* AppDelegate.swift in Sources */,
 				BCB1A01227C32E1100D7B8FD /* SceneDelegate.swift in Sources */,
 				BC8BDC0327C38938008E38F3 /* Card.swift in Sources */,

--- a/PockerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PockerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -16,7 +16,18 @@
 		BCB1A01927C32E1200D7B8FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BCB1A01827C32E1200D7B8FD /* Assets.xcassets */; };
 		BCB1A01C27C32E1200D7B8FD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BCB1A01A27C32E1200D7B8FD /* LaunchScreen.storyboard */; };
 		BCB1A02427C32EBE00D7B8FD /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = BCB1A02327C32EBE00D7B8FD /* README.md */; };
+		BCE3CB5427C5CFD2004F2AFE /* PokerGameAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB5327C5CFD2004F2AFE /* PokerGameAppTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		BCE3CB5527C5CFD2004F2AFE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BCB1A00427C32E1100D7B8FD /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BCB1A00B27C32E1100D7B8FD;
+			remoteInfo = PokerGameApp;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		BC8BDC0227C38938008E38F3 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
@@ -30,10 +41,19 @@
 		BCB1A01B27C32E1200D7B8FD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		BCB1A01D27C32E1200D7B8FD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BCB1A02327C32EBE00D7B8FD /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		BCE3CB5127C5CFD2004F2AFE /* PokerGameAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PokerGameAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BCE3CB5327C5CFD2004F2AFE /* PokerGameAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerGameAppTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		BCB1A00927C32E1100D7B8FD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BCE3CB4E27C5CFD2004F2AFE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -48,6 +68,7 @@
 			children = (
 				BCB1A02327C32EBE00D7B8FD /* README.md */,
 				BCB1A00E27C32E1100D7B8FD /* PockerGameApp */,
+				BCE3CB5227C5CFD2004F2AFE /* PokerGameAppTests */,
 				BCB1A00D27C32E1100D7B8FD /* Products */,
 			);
 			sourceTree = "<group>";
@@ -56,6 +77,7 @@
 			isa = PBXGroup;
 			children = (
 				BCB1A00C27C32E1100D7B8FD /* PokerGameApp.app */,
+				BCE3CB5127C5CFD2004F2AFE /* PokerGameAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -74,6 +96,14 @@
 				BCB1A01D27C32E1200D7B8FD /* Info.plist */,
 			);
 			path = PockerGameApp;
+			sourceTree = "<group>";
+		};
+		BCE3CB5227C5CFD2004F2AFE /* PokerGameAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				BCE3CB5327C5CFD2004F2AFE /* PokerGameAppTests.swift */,
+			);
+			path = PokerGameAppTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -96,6 +126,24 @@
 			productReference = BCB1A00C27C32E1100D7B8FD /* PokerGameApp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		BCE3CB5027C5CFD2004F2AFE /* PokerGameAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BCE3CB5927C5CFD2004F2AFE /* Build configuration list for PBXNativeTarget "PokerGameAppTests" */;
+			buildPhases = (
+				BCE3CB4D27C5CFD2004F2AFE /* Sources */,
+				BCE3CB4E27C5CFD2004F2AFE /* Frameworks */,
+				BCE3CB4F27C5CFD2004F2AFE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BCE3CB5627C5CFD2004F2AFE /* PBXTargetDependency */,
+			);
+			name = PokerGameAppTests;
+			productName = PokerGameAppTests;
+			productReference = BCE3CB5127C5CFD2004F2AFE /* PokerGameAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -108,6 +156,10 @@
 				TargetAttributes = {
 					BCB1A00B27C32E1100D7B8FD = {
 						CreatedOnToolsVersion = 13.2.1;
+					};
+					BCE3CB5027C5CFD2004F2AFE = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = BCB1A00B27C32E1100D7B8FD;
 					};
 				};
 			};
@@ -125,6 +177,7 @@
 			projectRoot = "";
 			targets = (
 				BCB1A00B27C32E1100D7B8FD /* PokerGameApp */,
+				BCE3CB5027C5CFD2004F2AFE /* PokerGameAppTests */,
 			);
 		};
 /* End PBXProject section */
@@ -138,6 +191,13 @@
 				BCB1A01927C32E1200D7B8FD /* Assets.xcassets in Resources */,
 				BCB1A02427C32EBE00D7B8FD /* README.md in Resources */,
 				BCB1A01727C32E1100D7B8FD /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BCE3CB4F27C5CFD2004F2AFE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -156,7 +216,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BCE3CB4D27C5CFD2004F2AFE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BCE3CB5427C5CFD2004F2AFE /* PokerGameAppTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		BCE3CB5627C5CFD2004F2AFE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BCB1A00B27C32E1100D7B8FD /* PokerGameApp */;
+			targetProxy = BCE3CB5527C5CFD2004F2AFE /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		BCB1A01527C32E1100D7B8FD /* Main.storyboard */ = {
@@ -352,6 +428,42 @@
 			};
 			name = Release;
 		};
+		BCE3CB5727C5CFD2004F2AFE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = A6HM92H898;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eddysong.PokerGameAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PokerGameApp.app/PokerGameApp";
+			};
+			name = Debug;
+		};
+		BCE3CB5827C5CFD2004F2AFE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = A6HM92H898;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eddysong.PokerGameAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PokerGameApp.app/PokerGameApp";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -369,6 +481,15 @@
 			buildConfigurations = (
 				BCB1A02127C32E1200D7B8FD /* Debug */,
 				BCB1A02227C32E1200D7B8FD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BCE3CB5927C5CFD2004F2AFE /* Build configuration list for PBXNativeTarget "PokerGameAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BCE3CB5727C5CFD2004F2AFE /* Debug */,
+				BCE3CB5827C5CFD2004F2AFE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PockerGameApp/PokerGameAppTests/PokerGameAppTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameAppTests.swift
@@ -1,0 +1,46 @@
+//
+//  PokerGameAppTests.swift
+//  PokerGameAppTests
+//
+//  Created by Bumgeun Song on 2022/02/23.
+//
+
+import XCTest
+@testable import PokerGameApp
+
+class PokerGameAppTests: XCTestCase {
+
+    func testExample() throws {
+        XCTAssertEqual(1+1, 2)
+    }
+    
+    func testCardDeckInitilzer() throws {
+        let deck = CardDeck()
+        XCTAssertEqual(deck.count, 52)
+    }
+    
+    func testIsSuffledWhenInitialized() throws {
+        let deck = CardDeck()
+        XCTAssertEqual("\(deck)", "[♠️A, ♠️2, ♠️3, ♠️4, ♠️5, ♠️6, ♠️7, ♠️8, ♠️9, ♠️10, ♠️J, ♠️Q, ♠️K, ♣️A, ♣️2, ♣️3, ♣️4, ♣️5, ♣️6, ♣️7, ♣️8, ♣️9, ♣️10, ♣️J, ♣️Q, ♣️K, ♥️A, ♥️2, ♥️3, ♥️4, ♥️5, ♥️6, ♥️7, ♥️8, ♥️9, ♥️10, ♥️J, ♥️Q, ♥️K, ♦️A, ♦️2, ♦️3, ♦️4, ♦️5, ♦️6, ♦️7, ♦️8, ♦️9, ♦️10, ♦️J, ♦️Q, ♦️K]")
+    }
+    
+    func testShuffle() throws {
+        var deck = CardDeck()
+        XCTAssertNotEqual("\(deck.shuffle())", "[♠️A, ♠️2, ♠️3, ♠️4, ♠️5, ♠️6, ♠️7, ♠️8, ♠️9, ♠️10, ♠️J, ♠️Q, ♠️K, ♣️A, ♣️2, ♣️3, ♣️4, ♣️5, ♣️6, ♣️7, ♣️8, ♣️9, ♣️10, ♣️J, ♣️Q, ♣️K, ♥️A, ♥️2, ♥️3, ♥️4, ♥️5, ♥️6, ♥️7, ♥️8, ♥️9, ♥️10, ♥️J, ♥️Q, ♥️K, ♦️A, ♦️2, ♦️3, ♦️4, ♦️5, ♦️6, ♦️7, ♦️8, ♦️9, ♦️10, ♦️J, ♦️Q, ♦️K]")
+    }
+    
+    func testDraw() throws {
+        var deck = CardDeck()
+        let _ = deck.draw()
+        XCTAssertTrue(deck.count == 51)
+        let _ = deck.draw()
+        XCTAssertTrue(deck.count == 50)
+    }
+    
+    func testReset() throws {
+        var deck = CardDeck()
+        let _ = deck.draw(), _ = deck.draw()
+        deck.reset()
+        XCTAssertEqual(deck.count, 52)
+    }
+}


### PR DESCRIPTION
**작업 목록**

- [x] CardDeck `struct` 추가
- [x] CardDeck `init` 구현
- [x] `shuffle` method 구현 (in-place / Fisher-Yates shuffle )
- [x] `draw` method 구현 
- [x] `reset` method 구현
- [x] viewController에 `testCardDeck` 구현

**학습 키워드**
- Class vs Struct
- Reference type은 Heap에, Value type은 Stack에 저장됨.
- Debug 할 때 메모리 주소 확인 (Reference type의 경우 변수명 옆에 표시)

- Fisher-Yates shuffle
- Case Iterable

- access control 키워드 
   - private: 해당 타입의 괄호 안에서만 접근 가능
   - fileprivate: 해당 타입이 정의된 소스 파일 안에서만 접근 가능
   - internal: 모듈 안에서만 접근 가능. 기본값.
   - public: 모듈 바깥에서도 접근 가능.
   - open: 퍼블릭과 범위는 같지만, override가 가능함.

- popLast() vs removeLast()

**고민과 해결**
- reset() 함수 구현.
   - 처음에는 reset을 할 때마다 initializer와 똑같이 52개 카드를 생성해서 초기화했습니다.
   - reset을 여러번 할 경우 불필요하게 카드를 계속 생성하는 것 같아서, defaultCards를 별도로 저장하고 해당 프로퍼티와 shuffle을 사용해 초기화하도록 구현했습니다.
   - 그럼에도 불구하고 reset 메소드 자체가 struct스럽지 않다는 점이 뭔가 찜찜했습니다. 
   - 사실 현재 CardDeck은 cards 프로퍼티 데이터밖에 없습니다. 어차피 불변값인 struct의 특성상, reset()보다는 상위 모듈에서 init을 다시 해서 사용하는 것이 자연스럽다고 생각했습니다. 
   - 하지만 일단 요구사항에 reset()이 있었기 때문에 현재 상태로 구현했습니다.

- popLast와 removeLast의 차이
   - 여태 removeLast를 별 생각없이 썼었는데, 만약 empty array일 경우 crash를 일으킨다는 사실을 알게 되었습니다.
   - optional을 return하는 popLast로 바꿔서 해결했습니다.  

- removeOne()을 draw()로 변경
   - 카드 게임 Domain에서 쓰이는 어휘로는 draw가 더 자연스러운 메서드 이름인 거 같아 변경해 봤습니다!