### PR TITLE
[푸코] Step03 - 카드덱 구현하고 테스트하기

### DIFF
--- a/PockerGameApp/PockerGameApp.xcodeproj/project.pbxproj
+++ b/PockerGameApp/PockerGameApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		D267E90E27C31E91009A2EA3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D267E90D27C31E91009A2EA3 /* Assets.xcassets */; };
 		D267E91127C31E91009A2EA3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D267E90F27C31E91009A2EA3 /* LaunchScreen.storyboard */; };
 		D26BD12C27C47169001D0AD4 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26BD12B27C47169001D0AD4 /* Card.swift */; };
+		D26BD13027C4B334001D0AD4 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26BD12F27C4B334001D0AD4 /* CardDeck.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		D267E91027C31E91009A2EA3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D267E91227C31E91009A2EA3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D26BD12B27C47169001D0AD4 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+		D26BD12F27C4B334001D0AD4 /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,6 +76,7 @@
 			isa = PBXGroup;
 			children = (
 				D26BD12B27C47169001D0AD4 /* Card.swift */,
+				D26BD12F27C4B334001D0AD4 /* CardDeck.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -150,6 +153,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D267E90927C31E90009A2EA3 /* ViewController.swift in Sources */,
+				D26BD13027C4B334001D0AD4 /* CardDeck.swift in Sources */,
 				D267E90527C31E90009A2EA3 /* AppDelegate.swift in Sources */,
 				D267E90727C31E90009A2EA3 /* SceneDelegate.swift in Sources */,
 				D26BD12C27C47169001D0AD4 /* Card.swift in Sources */,

--- a/PockerGameApp/PockerGameApp/Data/Card.swift
+++ b/PockerGameApp/PockerGameApp/Data/Card.swift
@@ -25,20 +25,23 @@ class Card: CustomStringConvertible{
     
     
     // 한정된 범위에 맞춰 enum 타입으로 수정
-    enum CardNumber: CustomStringConvertible{
-        case one, eleven, twelve, thirteen, others(Int)
+    enum CardNumber: CaseIterable ,CustomStringConvertible{
+        case one, two, three, four, five, six, seven, eight, nine, ten, eleven, twelve, thirteen
         var description: String{
             switch self {
-            case .one:
-                return "A"
-            case .eleven:
-                return "J"
-            case .twelve:
-                return "Q"
-            case .thirteen:
-                return "K"
-            case .others(let int):
-                return "\(int)"
+            case .one: return "A"
+            case .two: return "2"
+            case .three: return "3"
+            case .four: return "4"
+            case .five: return "5"
+            case .six: return "6"
+            case .seven: return "7"
+            case .eight: return "8"
+            case .nine: return "9"
+            case .ten: return "10"
+            case .eleven: return "J"
+            case .twelve: return "Q"
+            case .thirteen: return "K"
             }
         }
     }

--- a/PockerGameApp/PockerGameApp/Data/Card.swift
+++ b/PockerGameApp/PockerGameApp/Data/Card.swift
@@ -18,43 +18,28 @@ class Card: CustomStringConvertible{
     }
     
     // 랜덤 문양, 숫자의 카드 인스턴스 초기화
-    init(){
-        guard let shapeRandomNum = Shape.allCases.randomElement() else{
-            print("적절한 Case 값을 찾지 못하였습니다.")
-            fatalError()
-        }
-        
-        let cardRandomNum = Int.random(in: 1...13)
-        
-        self.number = CardNumber(num: cardRandomNum)
-        self.shape = shapeRandomNum
+    init(number: Card.CardNumber, shape: Card.Shape){
+        self.number = number
+        self.shape = shape
     }
     
-    // 변경해줘야 하는 값의 종류가 다소 많은 편이며, 카드의 값을 오로지 숫자로만 사용하는 놀이 등도 존재하므로 숫자와 문자열 모두 보관할 수 있는 형태를 생각함. 고유한 값으로 존재하거나 꼭 참조될 필요가 없으므로 Struct로 표현
-    struct CardNumber: CustomStringConvertible{
-        private let number: Int
+    
+    // 한정된 범위에 맞춰 enum 타입으로 수정
+    enum CardNumber: CustomStringConvertible{
+        case one, eleven, twelve, thirteen, others(Int)
         var description: String{
-            switch number{
-            case 1:
+            switch self {
+            case .one:
                 return "A"
-            case 11:
+            case .eleven:
                 return "J"
-            case 12:
+            case .twelve:
                 return "Q"
-            case 13:
+            case .thirteen:
                 return "K"
-            default:
-                return number.description
+            case .others(let int):
+                return "\(int)"
             }
-        }
-        
-        init(num: Int){
-            guard num <= 13 || num != 0 else{
-                print("적절하지 못한 값이 발견되었습니다 : \(num)")
-                fatalError()
-            }
-            
-            number = num
         }
     }
 

--- a/PockerGameApp/PockerGameApp/Data/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/Data/CardDeck.swift
@@ -18,10 +18,22 @@ struct CardDeck{
     }
     
     mutating func shuffle(){
-        var countNumbers = Array(1..<deck.count)
+        var shuffledDeck: [Card] = []
+        
+        while !deck.isEmpty{
+            let index = Int.random(in: 0..<deck.count)
+            shuffledDeck.append(deck[index])
+            deck.remove(at: index)
+        }
+        
+        deck = shuffledDeck
     }
     
     mutating func reset(){
+        guard !removedDeck.isEmpty else{
+            return
+        }
+        
         deck.append(contentsOf: removedDeck)
         deck.sort(by: { card1, card2 in
             card1.description > card2.description
@@ -29,7 +41,11 @@ struct CardDeck{
         removedDeck.removeAll()
     }
     
-    mutating func removeOne() -> Card{
+    mutating func removeOne() -> Card?{
+        guard !deck.isEmpty else{
+            return nil
+        }
+        
         let index = Int.random(in: 0..<deck.count)
         let removeCard = deck[index]
         
@@ -50,7 +66,7 @@ struct CardDeck{
             let card = Card(number: cardNumbers[numberIndex], shape: cardShapes[cardShapeIndex])
             deck.append(card)
             
-            if numberIndex % 12 == 0 && deck.count < 52{
+            if numberIndex == 12 && deck.count < 52{
                 cardShapeIndex += 1
                 numberIndex -= 12
             } else{

--- a/PockerGameApp/PockerGameApp/Data/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/Data/CardDeck.swift
@@ -1,0 +1,13 @@
+//
+//  CardDeck.swift
+//  PockerGameApp
+//
+//  Created by juntaek.oh on 2022/02/22.
+//
+
+import Foundation
+
+// CardDeck은 각각의 고유 인스턴스인 Card들을 담는 단순한 통 개념이므로 Struct로 구현
+struct CardDeck{
+    private var deck: [Card] = []
+}

--- a/PockerGameApp/PockerGameApp/Data/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/Data/CardDeck.swift
@@ -10,7 +10,8 @@ import Foundation
 // CardDeck은 각각의 고유 인스턴스인 Card들을 담는 단순한 통 개념이므로 Struct로 구현
 struct CardDeck{
     private var deck: [Card] = []
-    private var removedDeck: [Card] = []
+    // reset시, 다시 거둬들일 카드 기록
+    private var removedCards: [Card] = []
     
     func count() -> Int{
         let count = deck.count
@@ -30,27 +31,22 @@ struct CardDeck{
     }
     
     mutating func reset(){
-        guard !removedDeck.isEmpty else{
+        guard !removedCards.isEmpty else{
             return
         }
         
-        deck.append(contentsOf: removedDeck)
-        deck.sort(by: { card1, card2 in
-            card1.description > card2.description
-        })
-        removedDeck.removeAll()
+        deck.append(contentsOf: removedCards)
+        removedCards.removeAll()
+        deck.shuffle()
     }
     
     mutating func removeOne() -> Card?{
-        guard !deck.isEmpty else{
+        guard let removeCard = deck.last else{
             return nil
         }
         
-        let index = Int.random(in: 0..<deck.count)
-        let removeCard = deck[index]
-        
-        deck.remove(at: index)
-        removedDeck.append(removeCard)
+        deck.removeLast()
+        removedCards.append(removeCard)
         
         return removeCard
     }

--- a/PockerGameApp/PockerGameApp/Data/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/Data/CardDeck.swift
@@ -10,4 +10,56 @@ import Foundation
 // CardDeck은 각각의 고유 인스턴스인 Card들을 담는 단순한 통 개념이므로 Struct로 구현
 struct CardDeck{
     private var deck: [Card] = []
+    private var removedDeck: [Card] = []
+    
+    func count() -> Int{
+        let count = deck.count
+        return count
+    }
+    
+    mutating func shuffle(){
+        var countNumbers = Array(1..<deck.count)
+    }
+    
+    mutating func reset(){
+        deck.append(contentsOf: removedDeck)
+        deck.sort(by: { card1, card2 in
+            card1.description > card2.description
+        })
+        removedDeck.removeAll()
+    }
+    
+    mutating func removeOne() -> Card{
+        let index = Int.random(in: 0..<deck.count)
+        let removeCard = deck[index]
+        
+        deck.remove(at: index)
+        removedDeck.append(removeCard)
+        
+        return removeCard
+    }
+    
+    init(){
+        let cardShapes = Card.Shape.allCases
+        var cardShapeIndex = 0
+        
+        let cardNumbers = Card.CardNumber.allCases
+        var numberIndex = 0
+        
+        while numberIndex < 13{
+            let card = Card(number: cardNumbers[numberIndex], shape: cardShapes[cardShapeIndex])
+            deck.append(card)
+            
+            if numberIndex % 12 == 0 && deck.count < 52{
+                cardShapeIndex += 1
+                numberIndex -= 12
+            } else{
+                numberIndex += 1
+            }
+        }
+        
+        deck.sort(by: { card1, card2 in
+            card1.description > card2.description
+        })
+    }
 }

--- a/PockerGameApp/PockerGameApp/ViewController.swift
+++ b/PockerGameApp/PockerGameApp/ViewController.swift
@@ -42,19 +42,8 @@ class ViewController: UIViewController {
     }
     
     func makeRandomCardInfo() -> Card?{
-        guard let cardRandomShape = Card.Shape.allCases.randomElement() else{
+        guard let cardRandomShape = Card.Shape.allCases.randomElement(), let cardRandomNum = Card.CardNumber.allCases.randomElement() else{
             return nil
-        }
-        
-        let randomNum = Int.random(in: 1...13)
-        var cardRandomNum: Card.CardNumber{
-            switch randomNum{
-            case 1: return Card.CardNumber.one
-            case 11: return Card.CardNumber.eleven
-            case 12: return Card.CardNumber.twelve
-            case 13: return Card.CardNumber.thirteen
-            default : return Card.CardNumber.others(randomNum)
-            }
         }
         
         let cardInfo = Card(number: cardRandomNum, shape: cardRandomShape)

--- a/PockerGameApp/PockerGameApp/ViewController.swift
+++ b/PockerGameApp/PockerGameApp/ViewController.swift
@@ -33,6 +33,8 @@ class ViewController: UIViewController {
                 self.present(alert, animated: true)
             }
         }
+        
+        testCardDeck()
     }
 
     func makeImageView(){
@@ -54,5 +56,29 @@ class ViewController: UIViewController {
     func showCardInfo(card: Card){
         // description 생략 시에도 description을 가져와서 출력
         print(card)
+    }
+    
+    func testCardDeck(){
+        // 카드 초기화
+        var deck = CardDeck()
+        // 초기화 카드 수 52장 확인
+        let firstDecks = deck.count()
+        
+        // 카드 셔플
+        deck.shuffle()
+        
+        deck.reset()
+        
+        // 카드 뽑기
+        let card1 = deck.removeOne()
+        let secondDecks = deck.count()
+        
+        // 카드 또뽑기
+        let card2 = deck.removeOne()
+        let thirdDecks = deck.count()
+        
+        // 카드 리셋
+        deck.reset()
+        let fourthDecks = deck.count()
     }
 }

--- a/PockerGameApp/PockerGameApp/ViewController.swift
+++ b/PockerGameApp/PockerGameApp/ViewController.swift
@@ -25,8 +25,13 @@ class ViewController: UIViewController {
         
         for _ in 0...6{
             makeImageView()
-            let cardInfo = makeCardInfo()
-            showCardInfo(card: cardInfo)
+            
+            if let cardInfo = makeRandomCardInfo(){
+                showCardInfo(card: cardInfo)
+            } else{
+                let alert = UIAlertController(title: "잘못된 호출", message: "모양이나 숫자 입력이 잘못되었습니다. 다시 확인해주세요.", preferredStyle: UIAlertController.Style.alert)
+                self.present(alert, animated: true)
+            }
         }
     }
 
@@ -36,13 +41,29 @@ class ViewController: UIViewController {
         self.horizonStack.addArrangedSubview(imageView)
     }
     
-    func makeCardInfo() -> Card{
-        let cardInfo = Card()
+    func makeRandomCardInfo() -> Card?{
+        guard let cardRandomShape = Card.Shape.allCases.randomElement() else{
+            return nil
+        }
+        
+        let randomNum = Int.random(in: 1...13)
+        var cardRandomNum: Card.CardNumber{
+            switch randomNum{
+            case 1: return Card.CardNumber.one
+            case 11: return Card.CardNumber.eleven
+            case 12: return Card.CardNumber.twelve
+            case 13: return Card.CardNumber.thirteen
+            default : return Card.CardNumber.others(randomNum)
+            }
+        }
+        
+        let cardInfo = Card(number: cardRandomNum, shape: cardRandomShape)
         
         return cardInfo
     }
     
     func showCardInfo(card: Card){
-        print(card.description)
+        // description 생략 시에도 description을 가져와서 출력
+        print(card)
     }
 }

--- a/README.md
+++ b/README.md
@@ -313,20 +313,23 @@ class Card: CustomStringConvertible{
     
     
     // 한정된 범위에 맞춰 enum 타입으로 수정
-    enum CardNumber: CustomStringConvertible{
-        case one, eleven, twelve, thirteen, others(Int)
+    enum CardNumber: CaseIterable ,CustomStringConvertible{
+        case one, two, three, four, five, six, seven, eight, nine, ten, eleven, twelve, thirteen
         var description: String{
             switch self {
-            case .one:
-                return "A"
-            case .eleven:
-                return "J"
-            case .twelve:
-                return "Q"
-            case .thirteen:
-                return "K"
-            case .others(let int):
-                return "\(int)"
+            case .one: return "A"
+            case .two: return "2"
+            case .three: return "3"
+            case .four: return "4"
+            case .five: return "5"
+            case .six: return "6"
+            case .seven: return "7"
+            case .eight: return "8"
+            case .nine: return "9"
+            case .ten: return "10"
+            case .eleven: return "J"
+            case .twelve: return "Q"
+            case .thirteen: return "K"
             }
         }
     }
@@ -386,19 +389,8 @@ class ViewController: UIViewController {
     }
     
     func makeRandomCardInfo() -> Card?{
-        guard let cardRandomShape = Card.Shape.allCases.randomElement() else{
+        guard let cardRandomShape = Card.Shape.allCases.randomElement(), let cardRandomNum = Card.CardNumber.allCases.randomElement() else{
             return nil
-        }
-        
-        let randomNum = Int.random(in: 1...13)
-        var cardRandomNum: Card.CardNumber{
-            switch randomNum{
-            case 1: return Card.CardNumber.one
-            case 11: return Card.CardNumber.eleven
-            case 12: return Card.CardNumber.twelve
-            case 13: return Card.CardNumber.thirteen
-            default : return Card.CardNumber.others(randomNum)
-            }
         }
         
         let cardInfo = Card(number: cardRandomNum, shape: cardRandomShape)
@@ -413,11 +405,17 @@ class ViewController: UIViewController {
 }
 ``` 
 
-- CardNumber 또한 한정된 범위를 지니고 있으므로 enum 타입으로 수정했으며, 특수한 문자 변환 없는 숫자들은 연관값을 사용하여 문자열화
+- CardNumber 또한 한정된 범위를 지니고 있으므로 enum 타입으로 수정
 - 범용성이 떨어졌던 이전 수정의 이니셜라이저는 상위의 값을 전달받아 할당해주는 형태로 수정. (차후에는 Int, String 등을 받은 걸 변환시켜 할당하는 요소도 추가 고려 중)
 - makeCardInfo 함수는 makeRandomInfo 함수로 이름을 변경, 이에 맞춰 적절한 범위 내의 랜덤 값을 변환하여 Card에 값을 전달하도록 수정. 잘못된 값이 들어갈 경우 nil로 전달하도록 리턴 타입은 Card?
 - Card 인스턴스 생성 시, nil이 들어갈 경우 alert를 통해서 재입력 부탁 메세지 출력
 
 
 ## 카드덱 구현하고 테스트하기
-### 프로그래밍 요구사항
+### 기능 요구사항
+- 앞서 만든 모든 종류의 카드 객체 인스턴스를 포함하는 카드덱 구조체를 구현한다.
+- 객체지향 설계 방식에 맞도록 내부 속성을 모두 감추고 다음 인터페이스만 보이도록 구현한다.
+    + count 갖고 있는 카드 개수를 반환한다.
+    + shuffle 기능은 전체 카드를 랜덤하게 섞는다.
+    + removeOne 기능은 카드 인스턴스 중에 하나를 반환하고 목록에서 삭제한다.
+    + reset 처음처럼 모든 카드를 다시 채워넣는다.

--- a/README.md
+++ b/README.md
@@ -419,3 +419,94 @@ class ViewController: UIViewController {
     + shuffle 기능은 전체 카드를 랜덤하게 섞는다.
     + removeOne 기능은 카드 인스턴스 중에 하나를 반환하고 목록에서 삭제한다.
     + reset 처음처럼 모든 카드를 다시 채워넣는다.
+
+    ```swift
+    class ViewController: UIViewController {
+        private let cardImage = UIImage(named: "card-back")
+        
+        @IBOutlet weak var horizonStack: UIStackView!
+        
+        override func viewDidLoad() {
+            super.viewDidLoad()
+            
+            horizonStack.frame.size.height = horizonStack.frame.width / 7 * 1.27
+            horizonStack.distribution = .fillEqually
+            horizonStack.spacing = 3
+            
+            if let pattern = UIImage(named: "bg_pattern"){
+                self.view.backgroundColor = UIColor(patternImage: pattern)
+            }
+            
+            for _ in 0...6{
+                makeImageView()
+                
+                if let cardInfo = makeRandomCardInfo(){
+                    showCardInfo(card: cardInfo)
+                } else{
+                    let alert = UIAlertController(title: "잘못된 호출", message: "모양이나 숫자 입력이 잘못되었습니다. 다시 확인해주세요.", preferredStyle: UIAlertController.Style.alert)
+                    self.present(alert, animated: true)
+                }
+            }
+        }
+
+        func makeImageView(){
+            let imageView = UIImageView(image: self.cardImage)
+
+            self.horizonStack.addArrangedSubview(imageView)
+        }
+        
+        func makeRandomCardInfo() -> Card?{
+            guard let cardRandomShape = Card.Shape.allCases.randomElement(), let cardRandomNum = Card.CardNumber.allCases.randomElement() else{
+                return nil
+            }
+            
+            let cardInfo = Card(number: cardRandomNum, shape: cardRandomShape)
+            
+            return cardInfo
+        }
+        
+        func showCardInfo(card: Card){
+            // description 생략 시에도 description을 가져와서 출력
+            print(card)
+        }
+    }
+    ``` 
+    * CardDeck에는 52장의 카드를 담을 deck 프로퍼티와 드로우된 카드들을 기록하는 removedCards로 구현 (덱에서 나간 카드들은 현실에서도 어떤 카드인지 공개되지 않으므로 private 설정 후, 어떤 메서드로도 내부를 볼 수 있는 로직 구현하지 않음)
+    * count 구현, 보통 개수는 출력과 관련되는 경우가 많으므로 return 값 설정
+    * shuffle 구현, Fisher-Yates shuffle 알고리즘에 맞춰 랜덤 값으로 나온 인덱스의 value를 신규 덱에 넣고 기존 덱에서는 삭제. 이를 기존 덱이 빌 때까지 반복한 뒤, 반복이 끝나면 신규 덱을 기존 덱에 할당
+    * reset 구현, 빠진 카드들을 다시 주워담아서 합치는 형태로 구현했으며 빠진 카드가 없으면 괜히 로직이 실행되지 않도록 guard 구문 작성
+    * removeOne 구현, 보통 카드를 드로우할 때에는 맨 뒷장이 빠지므로 removeLast로 구현. 남은 카드가 없을 수도 있으므로 리턴은 옵셔널 Card
+    * 카드 구성은 기본적으로 52장 세팅이므로 4개의 문양 별로 13장의 카드 생성 로직 구성
+
+- 상위 모듈에서 카드덱 기능을 확인할 수 있도록 테스트 코드를 추가한다
+- XCTest 같은 단위 테스트가 아니라, 카드덱 함수를 호출해서 원하는 데로 동작하는지 확인할 수 있는 코드를 작성한다
+    + 테스트 시나리오와 비슷한 형태로 테스트 구문 구현 ( guard 조건 시, 아래 구문 미실행 부분들도 추가로 검토 진행함 )
+    
+    ```swift
+    func testCardDeck(){
+        // 카드 초기화
+        var deck = CardDeck()
+        // 초기화 카드 수 52장 확인
+        let firstDecks = deck.count()
+        
+        // 카드 셔플
+        deck.shuffle()
+        
+        deck.reset()
+        
+        // 카드 뽑기
+        let card1 = deck.removeOne()
+        let secondDecks = deck.count()
+        
+        // 카드 또뽑기
+        let card2 = deck.removeOne()
+        let thirdDecks = deck.count()
+        
+        // 카드 리셋
+        deck.reset()
+        let fourthDecks = deck.count()
+    }
+    ```
+
+<img src = "https://user-images.githubusercontent.com/44107696/155133976-84732446-1b2b-4fbf-8ec3-169ef4477fbc.png" width="800" height="800">
+


### PR DESCRIPTION
## 작업 목록
- [x] Card 클래스 init / CardNumber 수정
- [x] 입력 오류 메세지 print 대신 alert 출력으로 변경
- [x] CardDeck 구조체 설계
- [x] shuffle 로직 구현
- [x] count, reset, removeOne 메서드 구현
- [x] 덱 안의 52장의 카드 생성 관련 init 구현

## 학습 키워드
1) Struct / Class
2) Fisher-Yates shuffle / Knuth shuffle 알고리즘
3) removeLast / popLast
4) breakpoint 위치 활용 및 print 없이 디버깅으로 확인하는 법
5) 접근제어자 (open, public, internal(default), fileprivate, private)
6) ARC (strong, weak, unowned)

## 고민과 해결
- Card.CardNumber enum 구성
: 처음에는 Associated Value를 활용하여 일반 숫자들은 others(Int) 형태로 활용하려고 했으나, 상위 레벨에서 해당 타입의 데이터를 Card의 인자로 전달하려니 2중 변환이 필요해짐. 이에 다른 사람들과의 대화도 진행하였고, 이후 13개 밖에 되지 않는 범위이니 전부 case로 구현하는 편이 나을 듯하여 수정 진행.

- CardDeck removeOne 함수
: 처음에는 기리 잡는 것처럼 카드를 제거하는 걸로 생각하고 Int.random을 인덱스 값으로 활용해서 덱의 카드 중 아무거나 하나를 제거하는 로직으로 구현. 이후 테스트 단계에서 예시를 보고 드로우를 의미하는 것을 깨닫고 마지막의 카드를 제거하는 로직으로 수정.
수정 중에 removeLast는 배열이 비어있을 때, 사용 시 crash가 발생하고 popLast는 nil을 반환하는 것을 알게됨. 다만 본인이 작성한 로직에서는 last의 카드가 없을 경우에는 함수를 종료하는 guard문이 있으므로 removeLast로 사용.

- CardDeck.init
: 이전과 동일하게 상위에서 호출 시, 적절한 상황에 맞춰 초기화될 수 있도록 구현해야 될 지에 대한 고민을 함. 다만 CardDeck 자체는 기본적으로 4개의 문양을 지닌 1~13까지의 카드로 구성되는 것이 기본이며, Struct로 구현한 것은 이 구조체가 가진 값에 더 의미를 두겠다는 판단이라 생각되어 52장의 카드를 디폴트로 가지는 초기화 형태로 구현.