### PR TITLE
[Mase] Step3 - 카드덱 구현하고 테스트하기

### DIFF
--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1E95A0F927C32768005FE52A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1E95A0F827C32768005FE52A /* Assets.xcassets */; };
 		1E95A0FC27C32768005FE52A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1E95A0FA27C32768005FE52A /* LaunchScreen.storyboard */; };
 		1E95A15827C4F6E0005FE52A /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E95A15727C4F6E0005FE52A /* Card.swift */; };
+		1E95A15C27C5C315005FE52A /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E95A15B27C5C315005FE52A /* CardDeck.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		1E95A0FB27C32768005FE52A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		1E95A0FD27C32768005FE52A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1E95A15727C4F6E0005FE52A /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+		1E95A15B27C5C315005FE52A /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +64,7 @@
 				1E95A0F127C32767005FE52A /* SceneDelegate.swift */,
 				1E95A0F327C32767005FE52A /* ViewController.swift */,
 				1E95A15727C4F6E0005FE52A /* Card.swift */,
+				1E95A15B27C5C315005FE52A /* CardDeck.swift */,
 				1E95A0F527C32767005FE52A /* Main.storyboard */,
 				1E95A0F827C32768005FE52A /* Assets.xcassets */,
 				1E95A0FA27C32768005FE52A /* LaunchScreen.storyboard */,
@@ -142,6 +145,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1E95A0F427C32767005FE52A /* ViewController.swift in Sources */,
+				1E95A15C27C5C315005FE52A /* CardDeck.swift in Sources */,
 				1E95A0F027C32767005FE52A /* AppDelegate.swift in Sources */,
 				1E95A0F227C32767005FE52A /* SceneDelegate.swift in Sources */,
 				1E95A15827C4F6E0005FE52A /* Card.swift in Sources */,

--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -15,7 +15,18 @@
 		1E95A0FC27C32768005FE52A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1E95A0FA27C32768005FE52A /* LaunchScreen.storyboard */; };
 		1E95A15827C4F6E0005FE52A /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E95A15727C4F6E0005FE52A /* Card.swift */; };
 		1E95A15C27C5C315005FE52A /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E95A15B27C5C315005FE52A /* CardDeck.swift */; };
+		1E95A1A427C61421005FE52A /* CardDeckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E95A1A327C61421005FE52A /* CardDeckTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1E95A1A527C61421005FE52A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1E95A0E427C32767005FE52A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1E95A0EB27C32767005FE52A;
+			remoteInfo = PokerGame;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		1E95A0EC27C32767005FE52A /* PokerGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PokerGame.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -28,10 +39,19 @@
 		1E95A0FD27C32768005FE52A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1E95A15727C4F6E0005FE52A /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		1E95A15B27C5C315005FE52A /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
+		1E95A1A127C61421005FE52A /* PokerGameTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PokerGameTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1E95A1A327C61421005FE52A /* CardDeckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeckTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		1E95A0E927C32767005FE52A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1E95A19E27C61421005FE52A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -45,6 +65,7 @@
 			isa = PBXGroup;
 			children = (
 				1E95A0EE27C32767005FE52A /* PokerGameApp */,
+				1E95A1A227C61421005FE52A /* PokerGameTests */,
 				1E95A0ED27C32767005FE52A /* Products */,
 			);
 			sourceTree = "<group>";
@@ -53,6 +74,7 @@
 			isa = PBXGroup;
 			children = (
 				1E95A0EC27C32767005FE52A /* PokerGame.app */,
+				1E95A1A127C61421005FE52A /* PokerGameTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -62,15 +84,23 @@
 			children = (
 				1E95A0EF27C32767005FE52A /* AppDelegate.swift */,
 				1E95A0F127C32767005FE52A /* SceneDelegate.swift */,
-				1E95A0F327C32767005FE52A /* ViewController.swift */,
 				1E95A15727C4F6E0005FE52A /* Card.swift */,
 				1E95A15B27C5C315005FE52A /* CardDeck.swift */,
+				1E95A0F327C32767005FE52A /* ViewController.swift */,
 				1E95A0F527C32767005FE52A /* Main.storyboard */,
 				1E95A0F827C32768005FE52A /* Assets.xcassets */,
 				1E95A0FA27C32768005FE52A /* LaunchScreen.storyboard */,
 				1E95A0FD27C32768005FE52A /* Info.plist */,
 			);
 			path = PokerGameApp;
+			sourceTree = "<group>";
+		};
+		1E95A1A227C61421005FE52A /* PokerGameTests */ = {
+			isa = PBXGroup;
+			children = (
+				1E95A1A327C61421005FE52A /* CardDeckTests.swift */,
+			);
+			path = PokerGameTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -93,6 +123,24 @@
 			productReference = 1E95A0EC27C32767005FE52A /* PokerGame.app */;
 			productType = "com.apple.product-type.application";
 		};
+		1E95A1A027C61421005FE52A /* PokerGameTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1E95A1A727C61421005FE52A /* Build configuration list for PBXNativeTarget "PokerGameTests" */;
+			buildPhases = (
+				1E95A19D27C61421005FE52A /* Sources */,
+				1E95A19E27C61421005FE52A /* Frameworks */,
+				1E95A19F27C61421005FE52A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1E95A1A627C61421005FE52A /* PBXTargetDependency */,
+			);
+			name = PokerGameTests;
+			productName = PokerGameTests;
+			productReference = 1E95A1A127C61421005FE52A /* PokerGameTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -105,6 +153,10 @@
 				TargetAttributes = {
 					1E95A0EB27C32767005FE52A = {
 						CreatedOnToolsVersion = 13.2.1;
+					};
+					1E95A1A027C61421005FE52A = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = 1E95A0EB27C32767005FE52A;
 					};
 				};
 			};
@@ -122,6 +174,7 @@
 			projectRoot = "";
 			targets = (
 				1E95A0EB27C32767005FE52A /* PokerGame */,
+				1E95A1A027C61421005FE52A /* PokerGameTests */,
 			);
 		};
 /* End PBXProject section */
@@ -134,6 +187,13 @@
 				1E95A0FC27C32768005FE52A /* LaunchScreen.storyboard in Resources */,
 				1E95A0F927C32768005FE52A /* Assets.xcassets in Resources */,
 				1E95A0F727C32767005FE52A /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1E95A19F27C61421005FE52A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -152,7 +212,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1E95A19D27C61421005FE52A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1E95A1A427C61421005FE52A /* CardDeckTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1E95A1A627C61421005FE52A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1E95A0EB27C32767005FE52A /* PokerGame */;
+			targetProxy = 1E95A1A527C61421005FE52A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		1E95A0F527C32767005FE52A /* Main.storyboard */ = {
@@ -346,6 +422,42 @@
 			};
 			name = Release;
 		};
+		1E95A1A827C61421005FE52A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MPN6WL3W3U;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sanghyeok.test.PokerGameTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PokerGame.app/PokerGame";
+			};
+			name = Debug;
+		};
+		1E95A1A927C61421005FE52A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MPN6WL3W3U;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sanghyeok.test.PokerGameTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PokerGame.app/PokerGame";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -363,6 +475,15 @@
 			buildConfigurations = (
 				1E95A10127C32768005FE52A /* Debug */,
 				1E95A10227C32768005FE52A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1E95A1A727C61421005FE52A /* Build configuration list for PBXNativeTarget "PokerGameTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1E95A1A827C61421005FE52A /* Debug */,
+				1E95A1A927C61421005FE52A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PokerGameApp/PokerGameApp.xcodeproj/xcshareddata/xcschemes/PokerGameApp.xcscheme
+++ b/PokerGameApp/PokerGameApp.xcodeproj/xcshareddata/xcschemes/PokerGameApp.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1E95A18627C613D9005FE52A"
+               BuildableName = "PokerGameTests.xctest"
+               BlueprintName = "PokerGameTests"
+               ReferencedContainer = "container:PokerGameApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Card {
+struct Card: Equatable {
     enum FaceData: String, CustomStringConvertible, CaseIterable {
         case spade
         case club

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -8,8 +8,7 @@
 import Foundation
 
 struct Card {
-    
-    enum FaceData: String, CustomStringConvertible {
+    enum FaceData: String, CustomStringConvertible, CaseIterable {
         case spade
         case club
         case heart
@@ -29,7 +28,7 @@ struct Card {
         }
     }
     
-    enum NumericData: Int, CustomStringConvertible {
+    enum NumericData: Int, CustomStringConvertible, CaseIterable {
         case ace = 1
         case two
         case three
@@ -58,7 +57,6 @@ struct Card {
                 return "K"
             }
         }
-        
     }
     
     private let faceData: FaceData

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -9,63 +9,62 @@ import Foundation
 
 struct Card {
     
-    enum CardData {
-        enum FaceData: String, CustomStringConvertible {
-            case spade
-            case club
-            case heart
-            case diamond
-            
-            var description: String {
-                switch self {
-                case .spade:
-                    return "♠"
-                case .club:
-                    return "♣"
-                case .heart:
-                    return "♥"
-                case .diamond:
-                    return "♦"
-                }
-            }
-        }
-
-        enum NumericData: Int, CustomStringConvertible {
-            case ace = 1
-            case two
-            case three
-            case four
-            case five
-            case six
-            case seven
-            case eight
-            case nine
-            case ten
-            case jack
-            case queen
-            case king
-            
-            var description: String {
-                switch self {
-                case .ace:
-                    return "A"
-                case .two, .three, .four, .five, .six, .seven, .eight, .nine, .ten:
-                    return "\(self.rawValue)"
-                case .jack:
-                    return "J"
-                case .queen:
-                    return "Q"
-                case .king:
-                    return "K"
-                }
+    enum FaceData: String, CustomStringConvertible {
+        case spade
+        case club
+        case heart
+        case diamond
+        
+        var description: String {
+            switch self {
+            case .spade:
+                return "♠"
+            case .club:
+                return "♣"
+            case .heart:
+                return "♥"
+            case .diamond:
+                return "♦"
             }
         }
     }
     
-    private let faceData: CardData.FaceData
-    private let numericData: CardData.NumericData
+    enum NumericData: Int, CustomStringConvertible {
+        case ace = 1
+        case two
+        case three
+        case four
+        case five
+        case six
+        case seven
+        case eight
+        case nine
+        case ten
+        case jack
+        case queen
+        case king
+        
+        var description: String {
+            switch self {
+            case .ace:
+                return "A"
+            case .two, .three, .four, .five, .six, .seven, .eight, .nine, .ten:
+                return "\(self.rawValue)"
+            case .jack:
+                return "J"
+            case .queen:
+                return "Q"
+            case .king:
+                return "K"
+            }
+        }
+        
+    }
     
-    init(faceData: Card.CardData.FaceData, numericData: Card.CardData.NumericData) {
+    private let faceData: FaceData
+    private let numericData: NumericData
+    
+    init(faceData: Card.FaceData, numericData: Card.NumericData) {
         self.faceData = faceData
         self.numericData = numericData
     }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -8,5 +8,43 @@
 import Foundation
 
 struct CardDeck {
+    var cards: [Card] = [] //private?
     
+    private var count: Int {
+        return cards.count
+    }
+    
+    init() {
+        setUpCards()
+    }
+    
+    mutating func setUpCards() {
+        let faces = Card.FaceData.allCases
+        let numerics = Card.NumericData.allCases
+        
+        faces.forEach { faceData in
+            numerics.forEach { numericData in
+                cards.append(Card(faceData: faceData, numericData: numericData))
+            }
+        }
+    }
+    
+    mutating func shuffle() {
+        var maxIndex = count - 1
+        
+        while maxIndex != 0 {
+            let randomIndex = Int.random(in: (0...maxIndex))
+            self.cards.swapAt(randomIndex, maxIndex)
+            maxIndex -= 1
+        }
+    }
+    
+    mutating func removeOne() -> Card {
+        return self.cards.remove(at: Int.random(in: (0..<count)))
+    }
+    
+    mutating func reset() {
+        cards.removeAll()
+        setUpCards()
+    }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 struct CardDeck {
-    var cards: [Card] = [] //private?
+    private var cards: [Card] = [] //private?
     
-    private var count: Int {
+    var count: Int {
         return cards.count
     }
     

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 struct CardDeck {
-    private var cards: [Card] = [] //private?
+    
+    private var cards: [Card] = []
     
     var count: Int {
         return cards.count
@@ -39,8 +40,8 @@ struct CardDeck {
         }
     }
     
-    mutating func draw() -> Card {
-        return self.cards.remove(at: Int.random(in: (0..<count)))
+    mutating func draw() -> Card? {
+        return count > 0 ? self.cards.remove(at: Int.random(in: (0..<count))) : nil
     }
     
     mutating func reset() {

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -1,0 +1,12 @@
+//
+//  CardDeck.swift
+//  PokerGame
+//
+//  Created by 김상혁 on 2022/02/23.
+//
+
+import Foundation
+
+struct CardDeck {
+    
+}

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -49,3 +49,9 @@ struct CardDeck {
         setUpCards()
     }
 }
+
+extension CardDeck: Equatable {
+    static func == (lhs: CardDeck, rhs: CardDeck) -> Bool {
+        return lhs.cards == rhs.cards
+    }
+}

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -39,7 +39,7 @@ struct CardDeck {
         }
     }
     
-    mutating func removeOne() -> Card {
+    mutating func draw() -> Card {
         return self.cards.remove(at: Int.random(in: (0..<count)))
     }
     

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -14,11 +14,6 @@ class ViewController: UIViewController {
         
         setUpBackgroundImage()
         addCardImageViewIntoCardStackView(repeat: 7)
-        
-        let myCard = Card(faceData: Card.FaceData.spade //짧게 '.spade'도 가능
-                          , numericData: Card.NumericData.jack) //짧게 '.jack'도 가능
-
-        print(myCard.description)
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -15,8 +15,8 @@ class ViewController: UIViewController {
         setUpBackgroundImage()
         addCardImageViewIntoCardStackView(repeat: 7)
         
-        let myCard = Card(faceData: Card.CardData.FaceData.spade //짧게 '.spade'도 가능
-                          , numericData: Card.CardData.NumericData.jack) //짧게 '.jack'도 가능
+        let myCard = Card(faceData: Card.FaceData.spade //짧게 '.spade'도 가능
+                          , numericData: Card.NumericData.jack) //짧게 '.jack'도 가능
 
         print(myCard.description)
     }

--- a/PokerGameApp/PokerGameTests/CardDeckTests.swift
+++ b/PokerGameApp/PokerGameTests/CardDeckTests.swift
@@ -44,11 +44,11 @@ class PokerGameTests: XCTestCase {
     }
     
     func testReset() {
-        var cardDeckBeforeReset = CardDeck()
-        cardDeckBeforeReset.shuffle()
-        XCTAssertNotEqual(cardDeckBeforeReset, cardDeck, "Wrong Card Deck After Shuffle")
+        let originalCardDeck = cardDeck
+        cardDeck.shuffle()
+        XCTAssertNotEqual(originalCardDeck, cardDeck, "Wrong Card Deck After Shuffle")
         
-        cardDeckBeforeReset.reset()
-        XCTAssertEqual(cardDeckBeforeReset, cardDeck, "Wrong Card Deck Count After Reset")
+        cardDeck.reset()
+        XCTAssertEqual(originalCardDeck, cardDeck, "Wrong Card Deck Count After Reset")
     }
 }

--- a/PokerGameApp/PokerGameTests/CardDeckTests.swift
+++ b/PokerGameApp/PokerGameTests/CardDeckTests.swift
@@ -46,7 +46,7 @@ class PokerGameTests: XCTestCase {
     func testReset() {
         var cardDeckBeforeReset = CardDeck()
         cardDeckBeforeReset.shuffle()
-        XCTAssertNotEqual(cardDeckBeforeReset, cardDeck, "Wrong Card Deck After Shffle")
+        XCTAssertNotEqual(cardDeckBeforeReset, cardDeck, "Wrong Card Deck After Shuffle")
         
         cardDeckBeforeReset.reset()
         XCTAssertEqual(cardDeckBeforeReset, cardDeck, "Wrong Card Deck Count After Reset")

--- a/PokerGameApp/PokerGameTests/CardDeckTests.swift
+++ b/PokerGameApp/PokerGameTests/CardDeckTests.swift
@@ -31,7 +31,6 @@ class PokerGameTests: XCTestCase {
         let cardDeckBeforeShuffle = cardDeck
         cardDeck.shuffle()
         
-        //shuffle하고난 전과 후가 동일한 경우도 존재하는데 이는 어떻게 처리?
         XCTAssertNotEqual(cardDeckBeforeShuffle, cardDeck, "Wrong Card Deck After Shuffle")
     }
     
@@ -46,11 +45,10 @@ class PokerGameTests: XCTestCase {
     
     func testReset() {
         var cardDeckBeforeReset = CardDeck()
-        cardDeckBeforeReset.shuffle() //testShuffle 과정이 중복됨
-        XCTAssertNotEqual(cardDeckBeforeReset, cardDeck, "Wrong Card Deck Shffle")
+        cardDeckBeforeReset.shuffle()
+        XCTAssertNotEqual(cardDeckBeforeReset, cardDeck, "Wrong Card Deck After Shffle")
         
         cardDeckBeforeReset.reset()
         XCTAssertEqual(cardDeckBeforeReset, cardDeck, "Wrong Card Deck Count After Reset")
     }
-    
 }

--- a/PokerGameApp/PokerGameTests/CardDeckTests.swift
+++ b/PokerGameApp/PokerGameTests/CardDeckTests.swift
@@ -49,6 +49,6 @@ class PokerGameTests: XCTestCase {
         XCTAssertNotEqual(originalCardDeck, cardDeck, "Wrong Card Deck After Shuffle")
         
         cardDeck.reset()
-        XCTAssertEqual(originalCardDeck, cardDeck, "Wrong Card Deck Count After Reset")
+        XCTAssertEqual(originalCardDeck, cardDeck, "Wrong Card Deck After Reset")
     }
 }

--- a/PokerGameApp/PokerGameTests/CardDeckTests.swift
+++ b/PokerGameApp/PokerGameTests/CardDeckTests.swift
@@ -1,0 +1,56 @@
+//
+//  PokerGameTests.swift
+//  PokerGameTests
+//
+//  Created by 김상혁 on 2022/02/23.
+//
+
+import XCTest
+@testable import PokerGame
+
+class PokerGameTests: XCTestCase {
+    private var cardDeck: CardDeck!
+    
+    override func setUp() {
+        cardDeck = CardDeck()
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        cardDeck = nil
+        super.tearDown()
+    }
+
+    
+    func testCount() {
+        let cardDeckCount = cardDeck.count
+        XCTAssertEqual(cardDeckCount, 52, "Wrong Initial Card Deck Count")
+    }
+    
+    func testShuffle() {
+        let cardDeckBeforeShuffle = cardDeck
+        cardDeck.shuffle()
+        
+        //shuffle하고난 전과 후가 동일한 경우도 존재하는데 이는 어떻게 처리?
+        XCTAssertNotEqual(cardDeckBeforeShuffle, cardDeck, "Wrong Card Deck After Shuffle")
+    }
+    
+    func testDraw() {
+        let cardDeckCountBeforeDraw = cardDeck.count
+        
+        _ = cardDeck.draw()
+        let cardDeckCountAfterDraw = cardDeck.count
+        
+        XCTAssertEqual(cardDeckCountBeforeDraw - 1, cardDeckCountAfterDraw, "Wrong Card Deck After Draw")
+    }
+    
+    func testReset() {
+        var cardDeckBeforeReset = CardDeck()
+        cardDeckBeforeReset.shuffle() //testShuffle 과정이 중복됨
+        XCTAssertNotEqual(cardDeckBeforeReset, cardDeck, "Wrong Card Deck Shffle")
+        
+        cardDeckBeforeReset.reset()
+        XCTAssertEqual(cardDeckBeforeReset, cardDeck, "Wrong Card Deck Count After Reset")
+    }
+    
+}


### PR DESCRIPTION
## 학습 키워드
- 접근제어자
- XCTest
- Equatable
- CaseIterable
- Fisher-Yates Algorithm

## 작업 목록
- [x] 모든 종류의 카드 객체를 포함하는 카드덱 구조체를 구현
- [x] 내부 속성을 감추고 객체지향에 맞게 설계
- [x] shuffle 로직을 직접 구현
- [x] 테스트 코드 추가

## 고민과 해결
`testReset()`에서 `reset()`에 대한 테스트를 하기 위해 `shuffle()`을 호출하는 과정이 있습니다.
그런데 이렇게 하다보니 `testReset()` 안에 `shuffle()`을 위한 테스트도 추가되어서
온전히 `reset()`에 대한 테스트라고 할 수 없을 뿐 더러
`shuffle()`에 대한 테스트 함수와 중복이 되지않나 하는 고민을 했습니다.

```swift
//이미 shuffle()에 대한 테스트 코드가 존재
func testShuffle() {
        let cardDeckBeforeShuffle = cardDeck
        cardDeck.shuffle()
        
        XCTAssertNotEqual(cardDeckBeforeShuffle, cardDeck, "Wrong Card Deck After Shuffle")
    }
```
```swift
func testReset() {
        let originalCardDeck = cardDeck
        cardDeck.shuffle() //reset()을 테스트 하기 위해 shuffle()을 호출함

        //그렇다면 shuffle()이 잘 되었는지에 대한 테스트도 또 해주어야하는데?
        XCTAssertNotEqual(originalCardDeck, cardDeck, "Wrong Card Deck After Shuffle")
        
        cardDeck.reset()
        XCTAssertEqual(originalCardDeck, cardDeck, "Wrong Card Deck After Reset")
        //결국 이렇게 되면 온전히 reset()만 테스트하는 것이 아니라,
        //shuffle()과 reset() 둘 다에 대한 테스트가 되는 것이 아닌가?

    }
```
이럴 경우 오로지 reset()만을 위한 테스트 코드를 작성하도록 해야할지
(예를 들어 reset()하기 전과 후의 카드 개수를 비교한다거나.. 그런데 그 방법도 엄밀히 생각해보면
카드 개수는 같지만 내용물이 다를 경우 제대로 reset된 것이 아니게 되니.. 머리가 복잡해지네요)

아니면 위 방식처럼 하나의 테스트 함수 안에
다른 메소드를 위한 테스트 코드를 추가적으로 사용해도 괜찮은지 궁금합니다.