### PR TITLE
[Eddy] Step 4: PockerGame, Player, Dealer 구현 및 테스트

### DIFF
--- a/PockerGameApp/PockerGameApp/Card.swift
+++ b/PockerGameApp/PockerGameApp/Card.swift
@@ -12,12 +12,16 @@ import Foundation
 // Card 객체는 고유성이 필요한 객체가 아니고 (하트 6는 모두 똑같은 하트 6임)
 // 꼭 변경 가능한 상태를 공유해야 하는 상황도 아니기 때문에 Struct를 선택했습니다.
 
-struct Card: CustomStringConvertible {
+struct Card: CustomStringConvertible, Equatable {
     let suit: CardSuit
     let number: CardNumber
     
     var description: String {
         return "\(suit.description)\(number.description)"
+    }
+    
+    public static func == (lhs: Card, rhs: Card) -> Bool {
+        return (lhs.suit == rhs.suit) && (lhs.number == rhs.number)
     }
 }
 

--- a/PockerGameApp/PockerGameApp/CardDeck.swift
+++ b/PockerGameApp/PockerGameApp/CardDeck.swift
@@ -28,9 +28,9 @@ struct CardDeck {
     
     public mutating func shuffle() {
         // Mordern Fisher-Yates Shuffle (in-place)
-        for i in 0..<cards.count-1 {
+        for unshuffledIndex in 0..<cards.count-1 {
             let roll = Int.random(in: 0..<cards.count)
-            cards.swapAt(i, roll)
+            cards.swapAt(unshuffledIndex, roll)
         }
     }
     

--- a/PockerGameApp/PockerGameApp/Dealer.swift
+++ b/PockerGameApp/PockerGameApp/Dealer.swift
@@ -1,0 +1,38 @@
+//
+//  Dealer.swift
+//  PokerGameApp
+//
+//  Created by Bumgeun Song on 2022/02/23.
+//
+
+import Foundation
+
+class Dealer: Playable {
+    var deck: CardDeck
+    var cards: [Card]
+    var players: [Player]
+    
+    init(deck: CardDeck, players: [Player], cards: [Card] = []) {
+        self.players = players
+        self.deck = deck
+        self.cards = cards
+    }
+    
+    func deal(numOfcards: Int) throws {
+        deck.shuffle()
+        
+        let allPlayers: [Playable] = players + [self]
+        for player in allPlayers {
+            var drawns = [Card]()
+            for _ in 0..<numOfcards {
+                guard let drawn = deck.draw() else { throw PokerGameError.tooManyPlayer }
+                drawns.append(drawn)
+            }
+            player.receive(cards: drawns)
+        }
+    }
+    
+    func receive(cards: [Card]) {
+        self.cards += cards
+    }
+}

--- a/PockerGameApp/PockerGameApp/Dealer.swift
+++ b/PockerGameApp/PockerGameApp/Dealer.swift
@@ -24,10 +24,12 @@ class Dealer: Playable {
         
         let allPlayers: [Playable] = players + [self]
         for player in allPlayers {
-            var drawns = [Card]()
-            for _ in 0..<numOfcards {
-                guard let drawn = deck.draw() else { throw PokerGameError.tooManyPlayer }
-                drawns.append(drawn)
+            let drawns = try (0..<numOfcards).map { _ -> Card in
+                if let drawn = deck.draw() {
+                    return drawn
+                } else {
+                    throw PokerGameError.outOfCards
+                }
             }
             player.receive(cards: drawns)
         }

--- a/PockerGameApp/PockerGameApp/Dealer.swift
+++ b/PockerGameApp/PockerGameApp/Dealer.swift
@@ -19,6 +19,7 @@ class Dealer: Playable {
     }
     
     func deal(numOfcards: Int) throws {
+        // Dealer shuffles right before dealing
         deck.shuffle()
         
         let allPlayers: [Playable] = players + [self]

--- a/PockerGameApp/PockerGameApp/Dealer.swift
+++ b/PockerGameApp/PockerGameApp/Dealer.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 class Dealer: Playable {
-    var deck: CardDeck
-    var cards: [Card]
-    var players: [Player]
+    private var deck: CardDeck
+    private var cards: [Card]
+    private var players: [Player]
     
     init(deck: CardDeck, players: [Player], cards: [Card] = []) {
         self.players = players

--- a/PockerGameApp/PockerGameApp/Player.swift
+++ b/PockerGameApp/PockerGameApp/Player.swift
@@ -17,6 +17,22 @@ class Player: Playable {
     
     static var candidates = ["Eddy", "Jason", "Chez", "Dale", "Sally", "Jed", "Jee", "Ebony", "Sol", "Gucci"]
     
+    static func getRandomPlayerNames(pick: Int) -> [String] {
+        
+        func getCombination(pick: Int, from array: [String]) -> [String] {
+            guard !array.isEmpty, pick > 0 else { return [] }
+            
+            let roll = Int.random(in: 0..<array.count)
+            let prefix = array[roll]
+            
+            if pick == 1 { return [prefix] }
+            let combinationOfRemains = getCombination(pick: pick-1, from: Array(array.dropFirst(roll)))
+            return [prefix] + combinationOfRemains
+        }
+        
+        return getCombination(pick: pick, from: Player.candidates)
+    }
+    
     init(name: String) {
         self.name = name
     }

--- a/PockerGameApp/PockerGameApp/Player.swift
+++ b/PockerGameApp/PockerGameApp/Player.swift
@@ -17,7 +17,7 @@ class Player: Playable {
     let name: String
     var cards: [Card] = []
     
-    static var candidates = ["Eddy", "Jason", "Chez", "Dale", "Selina", "Jed", "Jee", "Ebony", "Sol", "Gucci"]
+    static var candidates = ["Eddy", "Jason", "Chez", "Dale", "Sally", "Jed", "Jee", "Ebony", "Sol", "Gucci"]
     
     init(name: String) {
         self.name = name

--- a/PockerGameApp/PockerGameApp/Player.swift
+++ b/PockerGameApp/PockerGameApp/Player.swift
@@ -17,9 +17,7 @@ class Player: Playable {
     let name: String
     var cards: [Card] = []
     
-    static var candidates = [
-        "Eddy", "Jason", "Chez", "Dale", "Selina", "Jed", "Jee", "Ebony", "Sol", "Gucci"
-    ]
+    static var candidates = ["Eddy", "Jason", "Chez", "Dale", "Selina", "Jed", "Jee", "Ebony", "Sol", "Gucci"]
     
     init(name: String) {
         self.name = name

--- a/PockerGameApp/PockerGameApp/Player.swift
+++ b/PockerGameApp/PockerGameApp/Player.swift
@@ -21,11 +21,6 @@ class Player: Playable {
         self.name = name
     }
     
-    init() {
-        self.name = Player.candidates.randomElement()!
-        self.cards = []
-    }
-    
     func receive(cards: [Card]) {
         self.cards += cards
     }

--- a/PockerGameApp/PockerGameApp/Player.swift
+++ b/PockerGameApp/PockerGameApp/Player.swift
@@ -1,0 +1,36 @@
+//
+//  Player.swift
+//  PokerGameApp
+//
+//  Created by Bumgeun Song on 2022/02/23.
+//
+
+import Foundation
+
+protocol Playable {
+    var cards: [Card] { get }
+    
+    func receive(cards: [Card])
+}
+
+class Player: Playable {
+    let name: String
+    var cards: [Card] = []
+    
+    static var candidates = [
+        "Eddy", "Jason", "Chez", "Dale", "Selina", "Jed", "Jee", "Ebony", "Sol", "Gucci"
+    ]
+    
+    init(name: String) {
+        self.name = name
+    }
+    
+    init() {
+        self.name = Player.candidates.randomElement()!
+        self.cards = []
+    }
+    
+    func receive(cards: [Card]) {
+        self.cards += cards
+    }
+}

--- a/PockerGameApp/PockerGameApp/Player.swift
+++ b/PockerGameApp/PockerGameApp/Player.swift
@@ -8,14 +8,12 @@
 import Foundation
 
 protocol Playable {
-    var cards: [Card] { get }
-    
     func receive(cards: [Card])
 }
 
 class Player: Playable {
     let name: String
-    var cards: [Card] = []
+    private var cards: [Card] = []
     
     static var candidates = ["Eddy", "Jason", "Chez", "Dale", "Sally", "Jed", "Jee", "Ebony", "Sol", "Gucci"]
     

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -36,64 +36,6 @@ enum PokerType {
     }
 }
 
-protocol Playable {
-    var cards: [Card] { get }
-    
-    func receive(cards: [Card])
-}
-
-class Player: Playable {
-    let name: String
-    var cards: [Card] = []
-    
-    static var candidates = [
-        "Eddy", "Jason", "Chez", "Dale", "Selina", "Jed", "Jee", "Ebony", "Sol", "Gucci"
-    ]
-    
-    init(name: String) {
-        self.name = name
-    }
-    
-    init() {
-        self.name = Player.candidates.randomElement()!
-        self.cards = []
-    }
-    
-    func receive(cards: [Card]) {
-        self.cards += cards
-    }
-}
-
-class Dealer: Playable {
-    var deck: CardDeck
-    var cards: [Card]
-    var players: [Player]
-    
-    init(deck: CardDeck, players: [Player], cards: [Card] = []) {
-        self.players = players
-        self.deck = deck
-        self.cards = cards
-    }
-    
-    func deal(numOfcards: Int) throws {
-        deck.shuffle()
-        
-        let allPlayers: [Playable] = players + [self]
-        for player in allPlayers {
-            var drawns = [Card]()
-            for _ in 0..<numOfcards {
-                guard let drawn = deck.draw() else { throw PokerGameError.tooManyPlayer }
-                drawns.append(drawn)
-            }
-            player.receive(cards: drawns)
-        }
-    }
-    
-    func receive(cards: [Card]) {
-        self.cards += cards
-    }
-}
-
 enum PokerGameError: Error {
     case tooManyPlayer
 }

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -29,6 +29,8 @@ struct PokerGame {
 }
 
 protocol Playable {
+    var cards: [Card] { get }
+
     func receive(cards: [Card])
 }
 

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -11,8 +11,12 @@ struct PokerGame {
     var type: PokerType
     let dealer: Dealer
     
-    init(type: PokerType, numberOfPlayers: Int) {
+    init(type: PokerType, numberOfPlayers: Int) throws {
         self.type = type
+        guard (0...4).contains(numberOfPlayers) else {
+            throw PokerGameError.tooManyPlayer
+        }
+        
         let players = (0..<numberOfPlayers).map { _ in Player()
         }
         let dealer = Dealer(deck: CardDeck(), players: players)
@@ -38,4 +42,5 @@ enum PokerType {
 
 enum PokerGameError: Error {
     case tooManyPlayer
+    case outOfCards
 }

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -10,21 +10,9 @@ import Foundation
 struct PokerGame {
     var type: PokerType
     let dealer: Dealer
-    var players: [Player]
-    
-    var allPlayers: [Playable] {
-        players + [dealer]
-    }
     
     func start() throws {
-        for player in allPlayers {
-            do {
-                let dealt = try dealer.deal(numOfcards: type.rawValue)
-                player.receive(cards: dealt)
-            } catch {
-                print(error)
-            }
-        }
+        try dealer.deal(numOfcards: type.rawValue)
     }
 }
 
@@ -35,7 +23,7 @@ enum PokerType: Int {
 
 protocol Playable {
     var cards: [Card] { get }
-
+    
     func receive(cards: [Card])
 }
 
@@ -56,20 +44,27 @@ class Player: Playable {
 class Dealer: Playable {
     var deck: CardDeck
     var cards: [Card]
+    var players: [Player]
     
-    init(deck: CardDeck, cards: [Card] = []) {
+    init(deck: CardDeck, players: [Player], cards: [Card] = []) {
+        self.players = players
         self.deck = deck
         self.cards = cards
         self.deck.shuffle()
     }
     
-    func deal(numOfcards: Int) throws -> [Card] {
-        var cards = [Card]()
-        for _ in 0..<numOfcards {
-            guard let drawn = deck.draw() else { throw PokerGameError.tooManyPlayer }
-            cards.append(drawn)
+    func deal(numOfcards: Int) throws {
+        let allPlayers: [Playable] = players + [self]
+        for player in allPlayers {
+            
+            let dealt = [Card]()
+            for _ in 0..<numOfcards {
+                guard let drawn = deck.draw() else { throw PokerGameError.tooManyPlayer }
+                cards.append(drawn)
+            }
+            
+            player.receive(cards: dealt)
         }
-        return cards
     }
     
     func receive(cards: [Card]) {

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -17,7 +17,10 @@ struct PokerGame {
     }
     
     func start() {
-        
+        for player in players {
+            let dealt = dealer.deal(numOfcards: type.rawValue)
+            player.receive(cards: dealt)
+        }
     }
 }
 
@@ -28,6 +31,10 @@ class Player {
     init(name: String, cards: [Card] = []) {
         self.name = name
         self.cards = cards
+    }
+    
+    func receive(cards: [Card]) {
+        self.cards += cards
     }
 }
 

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -17,19 +17,7 @@ struct PokerGame {
             throw PokerGameError.tooManyPlayer
         }
         
-        func getRandomCombinations(pick: Int, from array: [String]) -> [String] {
-            guard !array.isEmpty, pick > 0 else { return [] }
-            
-            let roll = Int.random(in: 0..<array.count)
-            let prefix = array[roll]
-            
-            if pick == 1 { return [prefix] }
-            let combinationOfRemains = getRandomCombinations(pick: pick-1, from: Array(array.dropFirst(roll)))
-            return [prefix] + combinationOfRemains
-        }
-        
-        let names = getRandomCombinations(pick: numberOfPlayers, from: Player.candidates)
-        
+        let names = Player.getRandomPlayerNames(pick: numberOfPlayers)
         let players = names.map { name in Player(name: name) }
         let dealer = Dealer(deck: CardDeck(), players: players)
         self.dealer = dealer

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -56,14 +56,12 @@ class Dealer: Playable {
     func deal(numOfcards: Int) throws {
         let allPlayers: [Playable] = players + [self]
         for player in allPlayers {
-            
-            let dealt = [Card]()
+            var drawns = [Card]()
             for _ in 0..<numOfcards {
                 guard let drawn = deck.draw() else { throw PokerGameError.tooManyPlayer }
-                cards.append(drawn)
+                drawns.append(drawn)
             }
-            
-            player.receive(cards: dealt)
+            player.receive(cards: drawns)
         }
     }
     

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -12,21 +12,27 @@ struct PokerGame {
     let dealer: Dealer
     var players: [Player]
     
+    var allPlayers: [Playable] {
+        players + [dealer]
+    }
+    
     var numberOfPlayers: Int {
         players.count
     }
     
     func start() {
-        for player in players {
+        for player in allPlayers {
             let dealt = dealer.deal(numOfcards: type.rawValue)
             player.receive(cards: dealt)
         }
-        let dealt = dealer.deal(numOfcards: type.rawValue)
-        dealer.receive(cards: dealt)
     }
 }
 
-class Player {
+protocol Playable {
+    func receive(cards: [Card])
+}
+
+class Player: Playable {
     let name: String
     var cards: [Card]
     
@@ -40,7 +46,7 @@ class Player {
     }
 }
 
-class Dealer {
+class Dealer: Playable {
     var deck: CardDeck
     var cards: [Card]
     

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -11,6 +11,14 @@ struct PokerGame {
     var type: PokerType
     let dealer: Dealer
     
+    init(type: PokerType, numberOfPlayers: Int) {
+        self.type = type
+        let players = (0..<numberOfPlayers).map { _ in Player()
+        }
+        let dealer = Dealer(deck: CardDeck(), players: players)
+        self.dealer = dealer
+    }
+    
     func start() throws {
         try dealer.deal(numOfcards: type.numberOfCards)
     }
@@ -38,9 +46,18 @@ class Player: Playable {
     let name: String
     var cards: [Card]
     
+    static var candidates = [
+        "Eddy", "Jason", "Chez", "Dale", "Selina", "Jed", "Jee", "Ebony", "Sol", "Gucci"
+    ]
+    
     init(name: String, cards: [Card] = []) {
         self.name = name
         self.cards = cards
+    }
+    
+    init() {
+        self.name = Player.candidates.randomElement()!
+        self.cards = []
     }
     
     func receive(cards: [Card]) {
@@ -57,10 +74,11 @@ class Dealer: Playable {
         self.players = players
         self.deck = deck
         self.cards = cards
-        self.deck.shuffle()
     }
     
     func deal(numOfcards: Int) throws {
+        deck.shuffle()
+        
         let allPlayers: [Playable] = players + [self]
         for player in allPlayers {
             var drawns = [Card]()

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -44,15 +44,14 @@ protocol Playable {
 
 class Player: Playable {
     let name: String
-    var cards: [Card]
+    var cards: [Card] = []
     
     static var candidates = [
         "Eddy", "Jason", "Chez", "Dale", "Selina", "Jed", "Jee", "Ebony", "Sol", "Gucci"
     ]
     
-    init(name: String, cards: [Card] = []) {
+    init(name: String) {
         self.name = name
-        self.cards = cards
     }
     
     init() {

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -16,10 +16,6 @@ struct PokerGame {
         players + [dealer]
     }
     
-    var numberOfPlayers: Int {
-        players.count
-    }
-    
     func start() {
         for player in allPlayers {
             let dealt = dealer.deal(numOfcards: type.rawValue)

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -21,6 +21,8 @@ struct PokerGame {
             let dealt = dealer.deal(numOfcards: type.rawValue)
             player.receive(cards: dealt)
         }
+        let dealt = dealer.deal(numOfcards: type.rawValue)
+        dealer.receive(cards: dealt)
     }
 }
 
@@ -55,6 +57,10 @@ class Dealer {
             cards.append(drawn)
         }
         return cards
+    }
+    
+    func receive(cards: [Card]) {
+        self.cards += cards
     }
 }
 

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -17,8 +17,20 @@ struct PokerGame {
             throw PokerGameError.tooManyPlayer
         }
         
-        let players = (0..<numberOfPlayers).map { _ in Player()
+        func getRandomCombinations(pick: Int, from array: [String]) -> [String] {
+            guard !array.isEmpty, pick > 0 else { return [] }
+            
+            let roll = Int.random(in: 0..<array.count)
+            let prefix = array[roll]
+            
+            if pick == 1 { return [prefix] }
+            let combinationOfRemains = getRandomCombinations(pick: pick-1, from: Array(array.dropFirst(roll)))
+            return [prefix] + combinationOfRemains
         }
+        
+        let names = getRandomCombinations(pick: numberOfPlayers, from: Player.candidates)
+        
+        let players = names.map { name in Player(name: name) }
         let dealer = Dealer(deck: CardDeck(), players: players)
         self.dealer = dealer
     }

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -16,12 +16,21 @@ struct PokerGame {
         players + [dealer]
     }
     
-    func start() {
+    func start() throws {
         for player in allPlayers {
-            let dealt = dealer.deal(numOfcards: type.rawValue)
-            player.receive(cards: dealt)
+            do {
+                let dealt = try dealer.deal(numOfcards: type.rawValue)
+                player.receive(cards: dealt)
+            } catch {
+                print(error)
+            }
         }
     }
+}
+
+enum PokerType: Int {
+    case fiveStud = 5
+    case sevenStud = 7
 }
 
 protocol Playable {
@@ -54,10 +63,10 @@ class Dealer: Playable {
         self.deck.shuffle()
     }
     
-    func deal(numOfcards: Int) -> [Card] {
+    func deal(numOfcards: Int) throws -> [Card] {
         var cards = [Card]()
         for _ in 0..<numOfcards {
-            guard let drawn = deck.draw() else { return cards }
+            guard let drawn = deck.draw() else { throw PokerGameError.tooManyPlayer }
             cards.append(drawn)
         }
         return cards
@@ -68,7 +77,6 @@ class Dealer: Playable {
     }
 }
 
-enum PokerType: Int {
-    case fiveStud = 5
-    case sevenStud = 7
+enum PokerGameError: Error {
+    case tooManyPlayer
 }

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -1,0 +1,41 @@
+//
+//  PokerGame.swift
+//  PokerGameApp
+//
+//  Created by Bumgeun Song on 2022/02/23.
+//
+
+import Foundation
+
+struct PokerGame {
+    var type: PokerType
+    var players: [Player]
+    var numberOfPlayers: Int {
+        players.count
+    }
+}
+
+class Player {
+    let name: String
+    var cards: [Card]
+    
+    init(name: String, cards: [Card] = []) {
+        self.name = name
+        self.cards = cards
+    }
+}
+
+class Dealer {
+    var deck: CardDeck
+    var cards: [Card]
+    
+    init(deck: CardDeck, cards: [Card] = []) {
+        self.deck = deck
+        self.cards = cards
+    }
+}
+
+enum PokerType {
+    case fiveStud
+    case sevenStud
+}

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -12,13 +12,20 @@ struct PokerGame {
     let dealer: Dealer
     
     func start() throws {
-        try dealer.deal(numOfcards: type.rawValue)
+        try dealer.deal(numOfcards: type.numberOfCards)
     }
 }
 
-enum PokerType: Int {
-    case fiveStud = 5
-    case sevenStud = 7
+enum PokerType {
+    case fiveStud
+    case sevenStud
+    
+    var numberOfCards: Int {
+        switch self {
+        case .fiveStud: return 5
+        case .sevenStud: return 7
+        }
+    }
 }
 
 protocol Playable {

--- a/PockerGameApp/PockerGameApp/PokerGame.swift
+++ b/PockerGameApp/PockerGameApp/PokerGame.swift
@@ -9,9 +9,15 @@ import Foundation
 
 struct PokerGame {
     var type: PokerType
+    let dealer: Dealer
     var players: [Player]
+    
     var numberOfPlayers: Int {
         players.count
+    }
+    
+    func start() {
+        
     }
 }
 
@@ -32,10 +38,20 @@ class Dealer {
     init(deck: CardDeck, cards: [Card] = []) {
         self.deck = deck
         self.cards = cards
+        self.deck.shuffle()
+    }
+    
+    func deal(numOfcards: Int) -> [Card] {
+        var cards = [Card]()
+        for _ in 0..<numOfcards {
+            guard let drawn = deck.draw() else { return cards }
+            cards.append(drawn)
+        }
+        return cards
     }
 }
 
-enum PokerType {
-    case fiveStud
-    case sevenStud
+enum PokerType: Int {
+    case fiveStud = 5
+    case sevenStud = 7
 }

--- a/PockerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PockerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		BCB1A01C27C32E1200D7B8FD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BCB1A01A27C32E1200D7B8FD /* LaunchScreen.storyboard */; };
 		BCB1A02427C32EBE00D7B8FD /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = BCB1A02327C32EBE00D7B8FD /* README.md */; };
 		BCE3CB5427C5CFD2004F2AFE /* PokerGameAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB5327C5CFD2004F2AFE /* PokerGameAppTests.swift */; };
+		BCE3CB5B27C604FB004F2AFE /* PokerGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB5A27C604FB004F2AFE /* PokerGame.swift */; };
+		BCE3CB5C27C604FB004F2AFE /* PokerGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB5A27C604FB004F2AFE /* PokerGame.swift */; };
+		BCE3CB5D27C606D8004F2AFE /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8BDC0227C38938008E38F3 /* Card.swift */; };
+		BCE3CB5E27C6070F004F2AFE /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8BDC0627C4B525008E38F3 /* CardDeck.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,6 +47,7 @@
 		BCB1A02327C32EBE00D7B8FD /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		BCE3CB5127C5CFD2004F2AFE /* PokerGameAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PokerGameAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCE3CB5327C5CFD2004F2AFE /* PokerGameAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerGameAppTests.swift; sourceTree = "<group>"; };
+		BCE3CB5A27C604FB004F2AFE /* PokerGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerGame.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -90,6 +95,7 @@
 				BCB1A01327C32E1100D7B8FD /* ViewController.swift */,
 				BC8BDC0227C38938008E38F3 /* Card.swift */,
 				BC8BDC0627C4B525008E38F3 /* CardDeck.swift */,
+				BCE3CB5A27C604FB004F2AFE /* PokerGame.swift */,
 				BCB1A01527C32E1100D7B8FD /* Main.storyboard */,
 				BCB1A01827C32E1200D7B8FD /* Assets.xcassets */,
 				BCB1A01A27C32E1200D7B8FD /* LaunchScreen.storyboard */,
@@ -211,6 +217,7 @@
 				BCB1A01427C32E1100D7B8FD /* ViewController.swift in Sources */,
 				BC8BDC0727C4B525008E38F3 /* CardDeck.swift in Sources */,
 				BCB1A01027C32E1100D7B8FD /* AppDelegate.swift in Sources */,
+				BCE3CB5B27C604FB004F2AFE /* PokerGame.swift in Sources */,
 				BCB1A01227C32E1100D7B8FD /* SceneDelegate.swift in Sources */,
 				BC8BDC0327C38938008E38F3 /* Card.swift in Sources */,
 			);
@@ -221,6 +228,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				BCE3CB5427C5CFD2004F2AFE /* PokerGameAppTests.swift in Sources */,
+				BCE3CB5D27C606D8004F2AFE /* Card.swift in Sources */,
+				BCE3CB5E27C6070F004F2AFE /* CardDeck.swift in Sources */,
+				BCE3CB5C27C604FB004F2AFE /* PokerGame.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PockerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PockerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -16,11 +16,12 @@
 		BCB1A01927C32E1200D7B8FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BCB1A01827C32E1200D7B8FD /* Assets.xcassets */; };
 		BCB1A01C27C32E1200D7B8FD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BCB1A01A27C32E1200D7B8FD /* LaunchScreen.storyboard */; };
 		BCB1A02427C32EBE00D7B8FD /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = BCB1A02327C32EBE00D7B8FD /* README.md */; };
-		BCE3CB5427C5CFD2004F2AFE /* PokerGameAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB5327C5CFD2004F2AFE /* PokerGameAppTests.swift */; };
+		BCE3CB5427C5CFD2004F2AFE /* CardDeckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB5327C5CFD2004F2AFE /* CardDeckTests.swift */; };
 		BCE3CB5B27C604FB004F2AFE /* PokerGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB5A27C604FB004F2AFE /* PokerGame.swift */; };
 		BCE3CB5C27C604FB004F2AFE /* PokerGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB5A27C604FB004F2AFE /* PokerGame.swift */; };
 		BCE3CB5D27C606D8004F2AFE /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8BDC0227C38938008E38F3 /* Card.swift */; };
 		BCE3CB5E27C6070F004F2AFE /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8BDC0627C4B525008E38F3 /* CardDeck.swift */; };
+		BCE3CB6327C61119004F2AFE /* PokerGameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB6227C61119004F2AFE /* PokerGameTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,8 +47,9 @@
 		BCB1A01D27C32E1200D7B8FD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BCB1A02327C32EBE00D7B8FD /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		BCE3CB5127C5CFD2004F2AFE /* PokerGameAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PokerGameAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		BCE3CB5327C5CFD2004F2AFE /* PokerGameAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerGameAppTests.swift; sourceTree = "<group>"; };
+		BCE3CB5327C5CFD2004F2AFE /* CardDeckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeckTests.swift; sourceTree = "<group>"; };
 		BCE3CB5A27C604FB004F2AFE /* PokerGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerGame.swift; sourceTree = "<group>"; };
+		BCE3CB6227C61119004F2AFE /* PokerGameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerGameTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,7 +109,8 @@
 		BCE3CB5227C5CFD2004F2AFE /* PokerGameAppTests */ = {
 			isa = PBXGroup;
 			children = (
-				BCE3CB5327C5CFD2004F2AFE /* PokerGameAppTests.swift */,
+				BCE3CB5327C5CFD2004F2AFE /* CardDeckTests.swift */,
+				BCE3CB6227C61119004F2AFE /* PokerGameTests.swift */,
 			);
 			path = PokerGameAppTests;
 			sourceTree = "<group>";
@@ -227,8 +230,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BCE3CB5427C5CFD2004F2AFE /* PokerGameAppTests.swift in Sources */,
+				BCE3CB5427C5CFD2004F2AFE /* CardDeckTests.swift in Sources */,
 				BCE3CB5D27C606D8004F2AFE /* Card.swift in Sources */,
+				BCE3CB6327C61119004F2AFE /* PokerGameTests.swift in Sources */,
 				BCE3CB5E27C6070F004F2AFE /* CardDeck.swift in Sources */,
 				BCE3CB5C27C604FB004F2AFE /* PokerGame.swift in Sources */,
 			);

--- a/PockerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PockerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -22,6 +22,10 @@
 		BCE3CB5D27C606D8004F2AFE /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8BDC0227C38938008E38F3 /* Card.swift */; };
 		BCE3CB5E27C6070F004F2AFE /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8BDC0627C4B525008E38F3 /* CardDeck.swift */; };
 		BCE3CB6327C61119004F2AFE /* PokerGameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB6227C61119004F2AFE /* PokerGameTests.swift */; };
+		BCE3CB6627C66A4D004F2AFE /* Dealer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB6527C66A4D004F2AFE /* Dealer.swift */; };
+		BCE3CB6727C66A4D004F2AFE /* Dealer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB6527C66A4D004F2AFE /* Dealer.swift */; };
+		BCE3CB6927C66A73004F2AFE /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB6827C66A73004F2AFE /* Player.swift */; };
+		BCE3CB6A27C66A73004F2AFE /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3CB6827C66A73004F2AFE /* Player.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +54,8 @@
 		BCE3CB5327C5CFD2004F2AFE /* CardDeckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeckTests.swift; sourceTree = "<group>"; };
 		BCE3CB5A27C604FB004F2AFE /* PokerGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerGame.swift; sourceTree = "<group>"; };
 		BCE3CB6227C61119004F2AFE /* PokerGameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerGameTests.swift; sourceTree = "<group>"; };
+		BCE3CB6527C66A4D004F2AFE /* Dealer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dealer.swift; sourceTree = "<group>"; };
+		BCE3CB6827C66A73004F2AFE /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,6 +104,8 @@
 				BC8BDC0227C38938008E38F3 /* Card.swift */,
 				BC8BDC0627C4B525008E38F3 /* CardDeck.swift */,
 				BCE3CB5A27C604FB004F2AFE /* PokerGame.swift */,
+				BCE3CB6827C66A73004F2AFE /* Player.swift */,
+				BCE3CB6527C66A4D004F2AFE /* Dealer.swift */,
 				BCB1A01527C32E1100D7B8FD /* Main.storyboard */,
 				BCB1A01827C32E1200D7B8FD /* Assets.xcassets */,
 				BCB1A01A27C32E1200D7B8FD /* LaunchScreen.storyboard */,
@@ -219,7 +227,9 @@
 			files = (
 				BCB1A01427C32E1100D7B8FD /* ViewController.swift in Sources */,
 				BC8BDC0727C4B525008E38F3 /* CardDeck.swift in Sources */,
+				BCE3CB6627C66A4D004F2AFE /* Dealer.swift in Sources */,
 				BCB1A01027C32E1100D7B8FD /* AppDelegate.swift in Sources */,
+				BCE3CB6927C66A73004F2AFE /* Player.swift in Sources */,
 				BCE3CB5B27C604FB004F2AFE /* PokerGame.swift in Sources */,
 				BCB1A01227C32E1100D7B8FD /* SceneDelegate.swift in Sources */,
 				BC8BDC0327C38938008E38F3 /* Card.swift in Sources */,
@@ -232,7 +242,9 @@
 			files = (
 				BCE3CB5427C5CFD2004F2AFE /* CardDeckTests.swift in Sources */,
 				BCE3CB5D27C606D8004F2AFE /* Card.swift in Sources */,
+				BCE3CB6727C66A4D004F2AFE /* Dealer.swift in Sources */,
 				BCE3CB6327C61119004F2AFE /* PokerGameTests.swift in Sources */,
+				BCE3CB6A27C66A73004F2AFE /* Player.swift in Sources */,
 				BCE3CB5E27C6070F004F2AFE /* CardDeck.swift in Sources */,
 				BCE3CB5C27C604FB004F2AFE /* PokerGame.swift in Sources */,
 			);

--- a/PockerGameApp/PokerGameAppTests/CardDeckTests.swift
+++ b/PockerGameApp/PokerGameAppTests/CardDeckTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import PokerGameApp
 
-class PokerGameAppTests: XCTestCase {
+class CardDeckTests: XCTestCase {
 
     func testExample() throws {
         XCTAssertEqual(1+1, 2)

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -31,4 +31,14 @@ class PokerGameTests: XCTestCase {
         XCTAssertFalse(dealtToFail.count == 7)
     }
     
+    func testReceive() throws {
+        let john = Player(name: "John")
+        XCTAssertEqual(john.cards, [])
+        let randomCards = (0..<7).map {
+            Card(suit: .hearts, number: CardNumber(rawValue: $0))
+        }
+        john.receive(cards: [Card(suit: <#T##CardSuit#>, number: <#T##CardNumber#>)])
+        XCTAssertEqual(john.cards, [])
+    }
+
 }

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import PokerGameApp
 
 class PokerGameTests: XCTestCase {
-
+    
     func testExample() throws {
         XCTAssertEqual(1+1, 2)
     }
@@ -17,17 +17,17 @@ class PokerGameTests: XCTestCase {
     func testDeal() throws {
         let deck = CardDeck()
         let dealer = Dealer(deck: deck)
-        let dealt = dealer.deal(numOfcards: 7)
-        XCTAssertTrue(dealt.count == 7)
+        let dealt = try? dealer.deal(numOfcards: 7)
+        XCTAssertTrue(dealt?.count == 7)
     }
     
     func testDealFail() throws {
         let deck = CardDeck()
         let dealer = Dealer(deck: deck)
         for _ in 0..<7 {
-            let _ = dealer.deal(numOfcards: 7)
+            let _ = try dealer.deal(numOfcards: 7)
         }
-        let dealtToFail = dealer.deal(numOfcards: 7)
+        let dealtToFail = try dealer.deal(numOfcards: 7)
         XCTAssertFalse(dealtToFail.count == 7)
     }
     
@@ -81,5 +81,5 @@ class PokerGameTests: XCTestCase {
             XCTAssertEqual(player.cards.count, 5)
         }
     }
-
+    
 }

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -9,24 +9,21 @@ import XCTest
 @testable import PokerGameApp
 
 class PokerGameTests: XCTestCase {
-    var testPlayers: [Player]!
-    var deck: CardDeck!
-    var dealer: Dealer!
-    
-    override func setUp() {
-        self.testPlayers = [
-            Player(name: "Eddy"),
-            Player(name: "Jason"),
-            Player(name: "Chez"),
-            Player(name: "Gucci"),
-            Player(name: "Ebony")
-        ]
-        self.deck = CardDeck()
-        self.dealer = Dealer(deck: deck, players: testPlayers)
-    }
     
     func testExample() throws {
         XCTAssertEqual(1+1, 2)
+    }
+    
+    func testDeal() {
+        let testPlayers = (0..<5).map { _ in Player() }
+        let testNumber = 5
+        let dealer = Dealer(deck: CardDeck(), players: testPlayers)
+        
+        try? dealer.deal(numOfcards: testNumber)
+        
+        for players in testPlayers {
+            XCTAssertEqual(players.cards.count, testNumber)
+        }
     }
     
     func testReceive() throws {
@@ -43,25 +40,15 @@ class PokerGameTests: XCTestCase {
     }
     
     func testSevenStudGame() throws {
-        let pokerGame = PokerGame(type: .sevenStud, dealer: dealer)
+        let pokerGame = PokerGame(type: .sevenStud, numberOfPlayers: 5)
         
-        try? pokerGame.start()
-        
-        let allPlayers: [Playable] = dealer.players + [dealer]
-        for player in allPlayers {
-            XCTAssertEqual(player.cards.count, 7)
-        }
+        try pokerGame.start()
     }
     
     func testFiveStudGame() throws {
-        let pokerGame = PokerGame(type: .fiveStud, dealer: dealer)
+        let pokerGame = PokerGame(type: .fiveStud, numberOfPlayers: 5)
         
-        try? pokerGame.start()
-        
-        let allPlayers: [Playable] = dealer.players + [dealer]
-        for player in allPlayers {
-            XCTAssertEqual(player.cards.count, 5)
-        }
+        try pokerGame.start()
     }
     
     

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -56,7 +56,7 @@ class PokerGameTests: XCTestCase {
         
         let pokerGame = PokerGame(type: .sevenStud, dealer: dealer, players: testPlayers)
         
-        pokerGame.start()
+        try? pokerGame.start()
         for player in pokerGame.allPlayers {
             XCTAssertEqual(player.cards.count, 7)
         }
@@ -76,7 +76,7 @@ class PokerGameTests: XCTestCase {
         
         let pokerGame = PokerGame(type: .fiveStud, dealer: dealer, players: testPlayers)
         
-        pokerGame.start()
+        try? pokerGame.start()
         for player in pokerGame.allPlayers {
             XCTAssertEqual(player.cards.count, 5)
         }

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -20,7 +20,6 @@ class PokerGameTests: XCTestCase {
         let dealer = Dealer(deck: CardDeck(), players: testPlayers)
         
         try? dealer.deal(numOfcards: testNumber)
-        
         for players in testPlayers {
             XCTAssertEqual(players.cards.count, testNumber)
         }

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -1,0 +1,17 @@
+//
+//  PokerGameTests.swift
+//  PokerGameAppTests
+//
+//  Created by Bumgeun Song on 2022/02/23.
+//
+
+import XCTest
+@testable import PokerGameApp
+
+class PokerGameTests: XCTestCase {
+
+    func testExample() throws {
+        XCTAssertEqual(1+1, 2)
+    }
+
+}

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -14,7 +14,7 @@ class PokerGameTests: XCTestCase {
         XCTAssertEqual(1+1, 2)
     }
     
-    func testDeal() {
+    func testDealerDeal() {
         let testPlayers = (0..<5).map { _ in Player() }
         let testNumber = 5
         let dealer = Dealer(deck: CardDeck(), players: testPlayers)
@@ -26,7 +26,7 @@ class PokerGameTests: XCTestCase {
         }
     }
     
-    func testReceive() throws {
+    func testPlayerReceive() throws {
         let john = Player(name: "John")
         
         XCTAssertEqual(john.cards, [])
@@ -52,24 +52,11 @@ class PokerGameTests: XCTestCase {
     }
     
     
-    func testDealwithTooManyPlayer() throws {
-        let testPlayers = [
-            Player(name: "Eddy"),
-            Player(name: "Jason"),
-            Player(name: "Chez"),
-            Player(name: "Gucci"),
-            Player(name: "Dale"),
-            Player(name: "Seilna"),
-            Player(name: "Jed"),
-            Player(name: "Jee"),
-            Player(name: "Ebony")
-        ]
-        
-        let deck = CardDeck()
-        let dealer = Dealer(deck: deck, players: testPlayers)
+    func testWithTooManyPlayer() throws {
+        let pokerGame = PokerGame(type: .sevenStud, numberOfPlayers: 8)
         
         var thrownError: Error!
-        XCTAssertThrowsError(try dealer.deal(numOfcards: PokerType.sevenStud.numberOfCards)) {
+        XCTAssertThrowsError(try pokerGame.start()) {
             thrownError = $0
         }
         XCTAssertTrue(thrownError as? PokerGameError == .tooManyPlayer)

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -14,16 +14,18 @@ class PokerGameTests: XCTestCase {
         XCTAssertEqual(1+1, 2)
     }
     
-    func testDealerDeal() {
-        let testPlayers = (0..<5).map { _ in Player() }
+    func testDealerDeal() throws {
+        let testNames = Player.getRandomPlayerNames(pick: 5)
+        let testPlayers = testNames.map { name in Player(name: name) }
         let testNumber = 5
         let dealer = Dealer(deck: CardDeck(), players: testPlayers)
         
-        try? dealer.deal(numOfcards: testNumber)
+        try dealer.deal(numOfcards: testNumber)
     }
     
-    func testWithTooManyCards() {
-        let testPlayers = (0..<5).map { _ in Player() }
+    func testWithTooManyCards() throws {
+        let testNames = Player.getRandomPlayerNames(pick: 5)
+        let testPlayers = testNames.map { name in Player(name: name) }
         let tooManyNumber = 10
         let dealer = Dealer(deck: CardDeck(), players: testPlayers)
         

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -25,6 +25,19 @@ class PokerGameTests: XCTestCase {
         }
     }
     
+    func testWithTooManyCards() {
+        let testPlayers = (0..<5).map { _ in Player() }
+        let tooManyNumber = 10
+        let dealer = Dealer(deck: CardDeck(), players: testPlayers)
+        
+        
+        var thrownError: Error!
+        XCTAssertThrowsError(try dealer.deal(numOfcards: tooManyNumber)) {
+            thrownError = $0
+        }
+        XCTAssertTrue(thrownError as? PokerGameError == .outOfCards)
+    }
+    
     func testPlayerReceive() throws {
         let john = Player(name: "John")
         
@@ -39,27 +52,24 @@ class PokerGameTests: XCTestCase {
     }
     
     func testSevenStudGame() throws {
-        let pokerGame = PokerGame(type: .sevenStud, numberOfPlayers: 5)
+        let pokerGame = try PokerGame(type: .sevenStud, numberOfPlayers: 3)
         
         try pokerGame.start()
     }
     
     func testFiveStudGame() throws {
-        let pokerGame = PokerGame(type: .fiveStud, numberOfPlayers: 5)
+        let pokerGame = try PokerGame(type: .fiveStud, numberOfPlayers: 4)
         
         try pokerGame.start()
     }
     
     
     func testWithTooManyPlayer() throws {
-        let pokerGame = PokerGame(type: .sevenStud, numberOfPlayers: 8)
-        
         var thrownError: Error!
-        XCTAssertThrowsError(try pokerGame.start()) {
+        XCTAssertThrowsError(try PokerGame(type: .sevenStud, numberOfPlayers: 8)) {
             thrownError = $0
         }
         XCTAssertTrue(thrownError as? PokerGameError == .tooManyPlayer)
     }
-    
     
 }

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -15,7 +15,8 @@ class PokerGameTests: XCTestCase {
     }
     
     func testDealerDeal() {
-        let testPlayers = (0..<5).map { _ in Player() }
+        let testNames = Player.getRandomPlayerNames(pick: 5)
+        let testPlayers = testNames.map { name in Player(name: name) }
         let testNumber = 5
         let dealer = Dealer(deck: CardDeck(), players: testPlayers)
         
@@ -23,7 +24,8 @@ class PokerGameTests: XCTestCase {
     }
     
     func testWithTooManyCards() {
-        let testPlayers = (0..<5).map { _ in Player() }
+        let testNames = Player.getRandomPlayerNames(pick: 5)
+        let testPlayers = testNames.map { name in Player(name: name) }
         let tooManyNumber = 10
         let dealer = Dealer(deck: CardDeck(), players: testPlayers)
         

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -46,6 +46,7 @@ class PokerGameTests: XCTestCase {
         let pokerGame = PokerGame(type: .sevenStud, dealer: dealer)
         
         try? pokerGame.start()
+        
         let allPlayers: [Playable] = dealer.players + [dealer]
         for player in allPlayers {
             XCTAssertEqual(player.cards.count, 7)
@@ -53,20 +54,10 @@ class PokerGameTests: XCTestCase {
     }
     
     func testFiveStudGame() throws {
-        let testPlayers = [
-            Player(name: "Eddy"),
-            Player(name: "Jason"),
-            Player(name: "Chez"),
-            Player(name: "Gucci"),
-            Player(name: "Ebony")
-        ]
-        
-        let deck = CardDeck()
-        let dealer = Dealer(deck: deck, players: testPlayers)
-        
         let pokerGame = PokerGame(type: .fiveStud, dealer: dealer)
         
         try? pokerGame.start()
+        
         let allPlayers: [Playable] = dealer.players + [dealer]
         for player in allPlayers {
             XCTAssertEqual(player.cards.count, 5)
@@ -74,7 +65,7 @@ class PokerGameTests: XCTestCase {
     }
     
     
-    func testDealFail() throws {
+    func testDealwithTooManyPlayer() throws {
         let testPlayers = [
             Player(name: "Eddy"),
             Player(name: "Jason"),
@@ -91,12 +82,10 @@ class PokerGameTests: XCTestCase {
         let dealer = Dealer(deck: deck, players: testPlayers)
         
         var thrownError: Error!
-        XCTAssertThrowsError(try dealer.deal(numOfcards: PokerType.sevenStud.rawValue)) {
-                    thrownError = $0
-                }
-        XCTAssertTrue(
-            thrownError as? PokerGameError == .tooManyPlayer)
-        
+        XCTAssertThrowsError(try dealer.deal(numOfcards: PokerType.sevenStud.numberOfCards)) {
+            thrownError = $0
+        }
+        XCTAssertTrue(thrownError as? PokerGameError == .tooManyPlayer)
     }
     
     

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -27,8 +27,11 @@ class PokerGameTests: XCTestCase {
         for _ in 0..<7 {
             let _ = try dealer.deal(numOfcards: 7)
         }
-        let dealtToFail = try dealer.deal(numOfcards: 7)
-        XCTAssertFalse(dealtToFail.count == 7)
+        do {
+            let dealtToFail = try dealer.deal(numOfcards: 7)
+        } catch {
+            XCTAssertEqual(error as! PokerGameError, PokerGameError.tooManyPlayer)
+        }
     }
     
     func testReceive() throws {

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -13,5 +13,22 @@ class PokerGameTests: XCTestCase {
     func testExample() throws {
         XCTAssertEqual(1+1, 2)
     }
-
+    
+    func testDeal() throws {
+        let deck = CardDeck()
+        let dealer = Dealer(deck: deck)
+        let dealt = dealer.deal(numOfcards: 7)
+        XCTAssertTrue(dealt.count == 7)
+    }
+    
+    func testDealFail() throws {
+        let deck = CardDeck()
+        let dealer = Dealer(deck: deck)
+        for _ in 0..<7 {
+            let _ = dealer.deal(numOfcards: 7)
+        }
+        let dealtToFail = dealer.deal(numOfcards: 7)
+        XCTAssertFalse(dealtToFail.count == 7)
+    }
+    
 }

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -9,66 +9,50 @@ import XCTest
 @testable import PokerGameApp
 
 class PokerGameTests: XCTestCase {
+    var testPlayers: [Player]!
+    var deck: CardDeck!
+    var dealer: Dealer!
+    
+    override func setUp() {
+        self.testPlayers = [
+            Player(name: "Eddy"),
+            Player(name: "Jason"),
+            Player(name: "Chez"),
+            Player(name: "Gucci"),
+            Player(name: "Ebony")
+        ]
+        self.deck = CardDeck()
+        self.dealer = Dealer(deck: deck, players: testPlayers)
+    }
     
     func testExample() throws {
         XCTAssertEqual(1+1, 2)
     }
     
-    func testDeal() throws {
-        let deck = CardDeck()
-        let dealer = Dealer(deck: deck)
-        let dealt = try? dealer.deal(numOfcards: 7)
-        XCTAssertTrue(dealt?.count == 7)
-    }
-    
-    func testDealFail() throws {
-        let deck = CardDeck()
-        let dealer = Dealer(deck: deck)
-        for _ in 0..<7 {
-            let _ = try dealer.deal(numOfcards: 7)
-        }
-        do {
-            let dealtToFail = try dealer.deal(numOfcards: 7)
-        } catch {
-            XCTAssertEqual(error as! PokerGameError, PokerGameError.tooManyPlayer)
-        }
-    }
-    
     func testReceive() throws {
         let john = Player(name: "John")
+        
         XCTAssertEqual(john.cards, [])
         
         let randomCards = (1...7).map {
             Card(suit: .hearts, number: CardNumber(rawValue: $0)!)
         }
         john.receive(cards: randomCards)
+        
         XCTAssertEqual(john.cards, randomCards)
     }
     
     func testSevenStudGame() throws {
-        let deck = CardDeck()
-        let dealer = Dealer(deck: deck)
-        
-        let testPlayers = [
-            Player(name: "Eddy"),
-            Player(name: "Jason"),
-            Player(name: "Chez"),
-            Player(name: "Gucci"),
-            Player(name: "Ebony")
-        ]
-        
-        let pokerGame = PokerGame(type: .sevenStud, dealer: dealer, players: testPlayers)
+        let pokerGame = PokerGame(type: .sevenStud, dealer: dealer)
         
         try? pokerGame.start()
-        for player in pokerGame.allPlayers {
+        let allPlayers: [Playable] = dealer.players + [dealer]
+        for player in allPlayers {
             XCTAssertEqual(player.cards.count, 7)
         }
     }
     
     func testFiveStudGame() throws {
-        let deck = CardDeck()
-        let dealer = Dealer(deck: deck)
-        
         let testPlayers = [
             Player(name: "Eddy"),
             Player(name: "Jason"),
@@ -77,12 +61,43 @@ class PokerGameTests: XCTestCase {
             Player(name: "Ebony")
         ]
         
-        let pokerGame = PokerGame(type: .fiveStud, dealer: dealer, players: testPlayers)
+        let deck = CardDeck()
+        let dealer = Dealer(deck: deck, players: testPlayers)
+        
+        let pokerGame = PokerGame(type: .fiveStud, dealer: dealer)
         
         try? pokerGame.start()
-        for player in pokerGame.allPlayers {
+        let allPlayers: [Playable] = dealer.players + [dealer]
+        for player in allPlayers {
             XCTAssertEqual(player.cards.count, 5)
         }
     }
+    
+    
+    func testDealFail() throws {
+        let testPlayers = [
+            Player(name: "Eddy"),
+            Player(name: "Jason"),
+            Player(name: "Chez"),
+            Player(name: "Gucci"),
+            Player(name: "Dale"),
+            Player(name: "Seilna"),
+            Player(name: "Jed"),
+            Player(name: "Jee"),
+            Player(name: "Ebony")
+        ]
+        
+        let deck = CardDeck()
+        let dealer = Dealer(deck: deck, players: testPlayers)
+        
+        var thrownError: Error!
+        XCTAssertThrowsError(try dealer.deal(numOfcards: PokerType.sevenStud.rawValue)) {
+                    thrownError = $0
+                }
+        XCTAssertTrue(
+            thrownError as? PokerGameError == .tooManyPlayer)
+        
+    }
+    
     
 }

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -57,7 +57,7 @@ class PokerGameTests: XCTestCase {
         let pokerGame = PokerGame(type: .sevenStud, dealer: dealer, players: testPlayers)
         
         pokerGame.start()
-        for player in testPlayers {
+        for player in pokerGame.allPlayers {
             XCTAssertEqual(player.cards.count, 7)
         }
     }
@@ -77,7 +77,7 @@ class PokerGameTests: XCTestCase {
         let pokerGame = PokerGame(type: .fiveStud, dealer: dealer, players: testPlayers)
         
         pokerGame.start()
-        for player in testPlayers {
+        for player in pokerGame.allPlayers {
             XCTAssertEqual(player.cards.count, 5)
         }
     }

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -42,7 +42,7 @@ class PokerGameTests: XCTestCase {
         XCTAssertEqual(john.cards, randomCards)
     }
     
-    func testGameStart() throws {
+    func testSevenStudGame() throws {
         let deck = CardDeck()
         let dealer = Dealer(deck: deck)
         
@@ -59,6 +59,26 @@ class PokerGameTests: XCTestCase {
         pokerGame.start()
         for player in testPlayers {
             XCTAssertEqual(player.cards.count, 7)
+        }
+    }
+    
+    func testFiveStudGame() throws {
+        let deck = CardDeck()
+        let dealer = Dealer(deck: deck)
+        
+        let testPlayers = [
+            Player(name: "Eddy"),
+            Player(name: "Jason"),
+            Player(name: "Chez"),
+            Player(name: "Gucci"),
+            Player(name: "Ebony")
+        ]
+        
+        let pokerGame = PokerGame(type: .fiveStud, dealer: dealer, players: testPlayers)
+        
+        pokerGame.start()
+        for player in testPlayers {
+            XCTAssertEqual(player.cards.count, 5)
         }
     }
 

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -20,9 +20,6 @@ class PokerGameTests: XCTestCase {
         let dealer = Dealer(deck: CardDeck(), players: testPlayers)
         
         try? dealer.deal(numOfcards: testNumber)
-        for players in testPlayers {
-            XCTAssertEqual(players.cards.count, testNumber)
-        }
     }
     
     func testWithTooManyCards() {
@@ -36,19 +33,6 @@ class PokerGameTests: XCTestCase {
             thrownError = $0
         }
         XCTAssertTrue(thrownError as? PokerGameError == .outOfCards)
-    }
-    
-    func testPlayerReceive() throws {
-        let john = Player(name: "John")
-        
-        XCTAssertEqual(john.cards, [])
-        
-        let randomCards = (1...7).map {
-            Card(suit: .hearts, number: CardNumber(rawValue: $0)!)
-        }
-        john.receive(cards: randomCards)
-        
-        XCTAssertEqual(john.cards, randomCards)
     }
     
     func testSevenStudGame() throws {

--- a/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
+++ b/PockerGameApp/PokerGameAppTests/PokerGameTests.swift
@@ -34,11 +34,32 @@ class PokerGameTests: XCTestCase {
     func testReceive() throws {
         let john = Player(name: "John")
         XCTAssertEqual(john.cards, [])
-        let randomCards = (0..<7).map {
-            Card(suit: .hearts, number: CardNumber(rawValue: $0))
+        
+        let randomCards = (1...7).map {
+            Card(suit: .hearts, number: CardNumber(rawValue: $0)!)
         }
-        john.receive(cards: [Card(suit: <#T##CardSuit#>, number: <#T##CardNumber#>)])
-        XCTAssertEqual(john.cards, [])
+        john.receive(cards: randomCards)
+        XCTAssertEqual(john.cards, randomCards)
+    }
+    
+    func testGameStart() throws {
+        let deck = CardDeck()
+        let dealer = Dealer(deck: deck)
+        
+        let testPlayers = [
+            Player(name: "Eddy"),
+            Player(name: "Jason"),
+            Player(name: "Chez"),
+            Player(name: "Gucci"),
+            Player(name: "Ebony")
+        ]
+        
+        let pokerGame = PokerGame(type: .sevenStud, dealer: dealer, players: testPlayers)
+        
+        pokerGame.start()
+        for player in testPlayers {
+            XCTAssertEqual(player.cards.count, 7)
+        }
     }
 
 }


### PR DESCRIPTION
## 작업 목록

- shuffle 내부의 `i` 변수 이름 의미있게 바꾸기
- Dealer 객체를 만들고,
    - Playable 타입 객체들에게 카드를 분배하는 역할`deal()`을 담당하게 함
- Player 객체를 만들고,
    - 이름이 주어질 때와 없을 때(랜덤)의 생성자 구현
- Playable 프로토콜 만들고,
    - card를 받을 수 있도록 정의 (receive)
    - Dealer, Player가 모두 따름.
- PockerGame 객체를 만들고,
    - 너무 많은 숫자의 플레이어를 막고 (tooManyPlayer error)
    - 직접 players, dealer 생성하는 역할을 담당하게 함.
    - 게임 시작 시 dealer에게 카드 분배 `deal()` 요청하는 역할을 담당하게 함.
- PokerGameTest를 만들고 다음을 테스트하게 함.
    - 카드 분배 시 부족할 때 에러를 잘 띄우는지.
    - fiveStud, sevenStud, 게임 생성이 잘 작동하는지
    - 플레이어 숫자가 초과되었을 때 에러를 잘 띄우는지.

## 학습 키워드
- 단위 테스트 관련
   - 에러를 테스트하는 방법
   - 에러 핸들링 방법과 적절한 에러 핸들링의 층위
   - Enum을 사용한 커스텀 에러 설계
   - SetUp()과 TearDown()
   - 타겟 파일의 설정 문제로 인한 에러 해결 방법
   - 테스트 함수의 네이밍
  
- 객체 설계 관련
   - protocol을 통해 객체가 추상적인 인터페이스에 의존하도록 만들기


## 고민과 해결

**어떻게 private method나 프로퍼티를 테스트할까**
- **(고민)** 예를 들어, `deal()`이 이루어졌으면, `XCTAssertEqual(john.cards, someCards)` 같은 함수를 통해 내부에 있는 Card의 갯수와 중복이 없는지 확인해야할 거 같다고 생각했습니다.
- 하지만 `card` 같은 변수엔 접근 제어를 해줘야 합니다. 포커패를 보거나 건드릴 수 있는 건 Player 자신만 가능해야 하기 때문이죠.
- 이런 private property의 내부 구현이 잘 되었는지 어떻게 파악할까? 라는 고민이 들어서 검색해보았습니다.

- **(해결)** [이 글](https://cocoacasts.com/how-to-unit-test-private-methods-in-swift)에서 **'private method를 어떻게 테스트하는가?' 는 잘못된 질문**이라고 알려주었습니다.
- 프라이빗 메서드는 테스트 타겟이 아닙니다. 퍼블릭 인터페이스에 대해서만 잘 작동하는지 보면 됩니다.
- 왜냐하면 우리는 **요구사항을 테스트하는 것이지, 구현을 테스트하는 게 아니기 때문**입니다.
- 생각해보니 맞는 말이었습니다. 그러면 구현을 바꿔서 리팩토링을 할때마다 테스트를 바꿔줘야할테니까요.
- 대신 구현에서 문제가 있는 부분에서는 **error를 적절하게 설계**해서 error를 클라이언트에게 전달해주면 되겠다는 생각이 들었습니다.
- 이후 Player.cards 갯수를 return 해야한다는 식의 요구사항(인터페이스)이 추가로 나온다면, 그때는 그걸 위한 퍼블릭 인터페이스를 설계한 후, 분배한 card 갯수가 적절하게 나오는지 확인하면 됩니다.
- 이 고민을 통해 **어디까지 테스트를 해야하는지**에 대한 힌트를 좀 더 얻었습니다.