### PR TITLE
[Damagucci-Juice] Step 3 : 카드덱 생성 및 print로 작동 테스트

### DIFF
--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -14,21 +14,18 @@ class Card: CustomStringConvertible {
         self.rank = rank
     }
     
-    //MARK: Nested enum을 사용한 이유
-    // Card 클래스 외부에서 열거형을 안 사용할 듯 합니다.
     enum Shape: Character {
         case spade = "♤"
         case heart = "♡"
         case diamond = "◇"
         case club = "♧"
     }
-    // Rank case를 나눈 이유는 타이핑의 경제성 때문에 나눴습니다.
+
     enum Rank: Int {
         case two = 2, three, four, five, six, seven, eight, nine, ten
         case ace = 1, jack = 11, queen = 12, king = 13
     }
     
-    //MARK: 실제 카드를 추상화해서 은유적으로 뒤집어 본다, 패를 뒤집어 본다는 느낌으로 함수명을 지었습니다.
     var description: String {
         switch rank {
         case .ace:

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class Card {
+class Card: CustomStringConvertible {
     let shape: Shape, rank: Rank
     init(shape: Shape, rank: Rank) {
         self.shape = shape
@@ -29,21 +29,18 @@ class Card {
     }
     
     //MARK: 실제 카드를 추상화해서 은유적으로 뒤집어 본다, 패를 뒤집어 본다는 느낌으로 함수명을 지었습니다.
-    func filp() -> String {
-        var output = ""
-        output += "\(shape.rawValue)"
+    var description: String {
         switch rank {
         case .ace:
-            output += "A"
+            return "\(shape.rawValue)A"
         case .jack:
-            output += "J"
+            return "\(shape.rawValue)J"
         case .queen:
-            output += "Q"
+            return "\(shape.rawValue)Q"
         case .king:
-            output += "K"
+            return "\(shape.rawValue)K"
         default:
-            output += "\(rank.rawValue)"
+            return "\(shape.rawValue)\(rank.rawValue)"
         }
-        return output
     }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -26,8 +26,19 @@ class CardDeck {
         return deck.count
     }
     //MARK: 처음처럼 카드 덱을 채워 넣는다(52장).
+    // 채우는 방법
+    // 1 : 'let initDeck'을 하나 만들어서 'deck = initdeck'
+    // 2 : '2중 for 문을 돌면서, 카드를 생성해서 채움 - 카드 생성시에 enum이 static이 아닌 이상 enum 형의 값을 넣을 수가 없음. 
     public func reset() {
-        
+        let shapeSet: Set<Card.Shape> = [.club, .diamond, .heart, .spade]
+        let rankSet: Set<Card.Rank> = [.ace, .two, .three, .four, .five, .six, .seven, .eight, .nine, .ten, .jack, .queen, .king]
+        for shape in shapeSet {
+            for rank in rankSet {
+                deck.append(Card(shape: shape, rank: rank))
+            }
+        }
+        print("카드 전체를 초기화했습니다.")
+        print("총 \(cardCount)장의 카드가 있습니다.")
     }
     //MARK: 무작위로 섞는다. Array.suffle(), suffled() 사용금지
     public func shuffle() {

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/*
+ > 카드 초기화
+ 카드 전체를 초기화했습니다.
+ 총 52장의 카드가 있습니다.
+
+ > 카드 섞기
+ 전체 52장의 카드를 섞었습니다.
+
+ > 카드 하나 뽑기
+ ♠️A
+ 총 51장의 카드가 남아있습니다.
+
+ > 카드 하나 뽑기
+ ♥️9
+ 총 50장의 카드가 남아있습니다.
+ */
+
+class CardDeck {
+    private var deck: Array<Card> = [Card]()
+    //TODO: 연산 속성은 퍼블릭으로 해도 되지 않을까? 연산 속성도 프라이빗으로 하고, 따로 메서드를 구현하면 코드 중복이 아닌가?
+    // 만약 연산 속성에 값을 저장을 못한다고 하면, 코드 중복이다. 값을 저장할 수 있다면, 잘 나눈것. 결론은 코드 중복이다.
+    // Error Message : Cannot assign to property: 'cardCount' is a get-only property
+    public var cardCount: Int {
+        return deck.count
+    }
+    //MARK: 처음처럼 카드 덱을 채워 넣는다(52장).
+    public func reset() {
+        
+    }
+    //MARK: 무작위로 섞는다. Array.suffle(), suffled() 사용금지
+    public func shuffle() {
+        
+    }
+    //MARK: 
+    public func removeOne() {
+        
+    }
+}

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -30,6 +30,7 @@ class CardDeck {
     // 1 : 'let initDeck'을 하나 만들어서 'deck = initdeck'
     // 2 : '2중 for 문을 돌면서, 카드를 생성해서 채움 - 카드 생성시에 enum이 static이 아닌 이상 enum 형의 값을 넣을 수가 없음. 
     func reset() {
+        deck.removeAll()
         let shapeSet: Set<Card.Shape> = [.club, .diamond, .heart, .spade]
         let rankSet: Set<Card.Rank> = [.ace, .two, .three, .four, .five, .six, .seven, .eight, .nine, .ten, .jack, .queen, .king]
         for shape in shapeSet {

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -33,8 +33,12 @@ class CardDeck {
     public func shuffle() {
         
     }
-    //MARK: 
-    public func removeOne() {
-        
+    //MARK: 덱 중에 하나를 pop한다
+    public func removeOne() -> Card {
+        let randomInt = Int.random(in: 0..<cardCount)
+        let removed = deck.remove(at: randomInt)
+        print(removed.description)
+        print("총 \(cardCount)장의 카드가 남았습니다.")
+        return removed
     }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -40,9 +40,16 @@ class CardDeck {
         print("카드 전체를 초기화했습니다.")
         print("총 \(cardCount)장의 카드가 있습니다.")
     }
-    //MARK: 무작위로 섞는다. Array.suffle(), suffled() 사용금지
+    //MARK: 무작위로 섞는다. Knuth suffle 알고리즘 적용
     public func shuffle() {
-        
+        let count = cardCount
+        for i in 0..<count - 1 {   // 0 ~ n - 2
+            let randomIndex = Int.random(in: i..<count)
+            let temp = deck[i]
+            deck[i] = deck[randomIndex]
+            deck[randomIndex] = temp
+        }
+        print("전체 \(cardCount)장의 카드를 섞었습니다.")
     }
     //MARK: 덱 중에 하나를 pop한다
     public func removeOne() -> Card {

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -22,14 +22,14 @@ class CardDeck {
     //TODO: 연산 속성은 퍼블릭으로 해도 되지 않을까? 연산 속성도 프라이빗으로 하고, 따로 메서드를 구현하면 코드 중복이 아닌가?
     // 만약 연산 속성에 값을 저장을 못한다고 하면, 코드 중복이다. 값을 저장할 수 있다면, 잘 나눈것. 결론은 코드 중복이다.
     // Error Message : Cannot assign to property: 'cardCount' is a get-only property
-    public var cardCount: Int {
+    var cardCount: Int {
         return deck.count
     }
     //MARK: 처음처럼 카드 덱을 채워 넣는다(52장).
     // 채우는 방법
     // 1 : 'let initDeck'을 하나 만들어서 'deck = initdeck'
     // 2 : '2중 for 문을 돌면서, 카드를 생성해서 채움 - 카드 생성시에 enum이 static이 아닌 이상 enum 형의 값을 넣을 수가 없음. 
-    public func reset() {
+    func reset() {
         let shapeSet: Set<Card.Shape> = [.club, .diamond, .heart, .spade]
         let rankSet: Set<Card.Rank> = [.ace, .two, .three, .four, .five, .six, .seven, .eight, .nine, .ten, .jack, .queen, .king]
         for shape in shapeSet {
@@ -41,7 +41,7 @@ class CardDeck {
         print("총 \(cardCount)장의 카드가 있습니다.")
     }
     //MARK: 무작위로 섞는다. Knuth suffle 알고리즘 적용
-    public func shuffle() {
+    func shuffle() {
         let count = cardCount
         for i in 0..<count - 1 {   // 0 ~ n - 2
             let randomIndex = Int.random(in: i..<count)
@@ -52,7 +52,7 @@ class CardDeck {
         print("전체 \(cardCount)장의 카드를 섞었습니다.")
     }
     //MARK: 덱 중에 하나를 pop한다
-    public func removeOne() -> Card {
+    func removeOne() -> Card {
         let randomInt = Int.random(in: 0..<cardCount)
         let removed = deck.remove(at: randomInt)
         print(removed.description)

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -27,6 +27,8 @@ class ViewController: UIViewController {
         let deck: CardDeck = CardDeck()
         deck.reset()
         deck.shuffle()
+        deck.removeOne()
+        print(deck.cardCount)
     }
     
     func createCard(XCoordinate: Int) {

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -26,6 +26,7 @@ class ViewController: UIViewController {
         //아직까진 둘 다로 선언해 보았을 때 그 차이를 모르겠다. 일단 let으로 하는게 좋은듯?!
         let deck: CardDeck = CardDeck()
         deck.reset()
+        deck.shuffle()
     }
     
     func createCard(XCoordinate: Int) {

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -23,8 +23,9 @@ class ViewController: UIViewController {
             offset += SizeOfCard.width + 3
         }
         //TODO: 클래스의 인스턴스를 let으로 선언했을 때와 var로 선언했을 때의 차이
-        let card = Card(shape: .club, rank: .ace)
-        print("\(card.description)")
+        //아직까진 둘 다로 선언해 보았을 때 그 차이를 모르겠다. 일단 let으로 하는게 좋은듯?!
+        let deck: CardDeck = CardDeck()
+        deck.reset()
     }
     
     func createCard(XCoordinate: Int) {

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -24,7 +24,7 @@ class ViewController: UIViewController {
         }
         //TODO: 클래스의 인스턴스를 let으로 선언했을 때와 var로 선언했을 때의 차이
         let card = Card(shape: .club, rank: .ace)
-        print("\(card.filp())")
+        print("\(card.description)")
     }
     
     func createCard(XCoordinate: Int) {


### PR DESCRIPTION
# 작업 목록
- [x] 앞서 만든 모든 종류의 카드 객체 인스턴스를 포함하는 카드덱 구조체를 구현한다.
- [x] 객체지향 설계 방식에 맞도록 내부 속성을 모두 감추고 다음 인터페이스만 보이도록 구현한다.
    - [x] count 갖고 있는 카드 개수를 반환한다.  `cardCount`
    - [x] shuffle 기능은 전체 카드를 랜덤하게 섞는다.
    - [x] removeOne 기능은 카드 인스턴스 중에 하나를 반환하고 목록에서 삭제한다.
    - [x] reset 처음처럼 모든 카드를 다시 채워넣는다.
- [ ] 메소드 매개변수와 리턴값은 어떤 타입이 좋을지, 속성으로 무엇이 필요한지, 불변 Immutable 인지 가변 mutable 인지 판단해야 한다.
- [x] 상위 모듈에서 카드덱 기능을 확인할 수 있도록 테스트 코드를 추가한다
- [x] XCTest 같은 단위 테스트가 아니라, 카드덱 함수를 호출해서 원하는 데로 동작하는지 확인할 수 있는 코드를 작성한다
- [x] 다양한 shuffle 알고리즘에 대해 찾아보고 랜덤하게 shuffle 처리하는 로직을 직접 구현한다.   -> `Knuth` 알고리즘 적용

# 학습 키워드
* 접근 제어
* Struct와 Class의 차이
* reset() 할 때 카드 객체가 메모리에서 어떻게 되는가?
* 메모리 분석 디버깅 툴
* ARC
    * 약한 참조
    * 미소유 참조
    
# 고민과 해결
## Q. 연산 프로퍼티에 값을  저장하는 것이 가능한가?
A. 불가능하다.  연산 프로퍼티는 get 만 가능.
```
Error Message : Cannot assign to property: 'cardCount' is a get-only property
```

## Q. `Card` 인스턴스를 만들때, 열거형으로 초기화를 해줘야하는데 어떻게 하는지 몰랐다.
A. 아래와 같은 방법으로 해결!
```
let shapeSet: Set<Card.Shape> = [.club, .diamond, .heart, .spade]
let rankSet: Set<Card.Rank> = [.ace, .two, .three, .four, .five, .six, .seven, .eight, .nine, .ten, .jack, .queen, .king]
for shape in shapeSet {
    for rank in rankSet {
        deck.append(Card(shape: shape, rank: rank))
    }
}
```

# 질문거리 

## reset()을 했을 때 카드 객체가 메모리에서 어찌 될까?
해당 함수가 아래와 같이 시작하는데, 메모리가 어떻게 움직이는지, 그리고 이것을 어떻게 테스트 할 수 있는지 궁금합니다.  해당 명령을 실행하면, 객채가 deinit되는 것인지 아니면 포인터만 사라지고, 어딘가에 존재하여 메모리 누수를 야기하는지 궁금합니다!

```
func reset() {
    deck.removeAll()
}
```
를 하면 내부적으로 
```
deck[0] = nil 
…
deck[lastIndex] = nil
```

이렇게 되는 것일까요?

# 구현 화면

![step3 구현 콘솔창](https://user-images.githubusercontent.com/50472122/155677692-ae6a8d59-dc4e-4f9f-b245-fde69575432b.png)
