### PR TITLE
[Jed] Step 2-5 : 리팩토링

### DIFF
--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		B52EC61E27C7582300C73E54 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52EC61D27C7582300C73E54 /* Player.swift */; };
 		B52EC62227C863EE00C73E54 /* Players.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52EC62127C863EE00C73E54 /* Players.swift */; };
 		B52EC62427C8B0E300C73E54 /* Cards.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52EC62327C8B0E300C73E54 /* Cards.swift */; };
+		B52EC62627C8C1CC00C73E54 /* Dealer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52EC62527C8C1CC00C73E54 /* Dealer.swift */; };
 		B56CA14227C3234D001DC373 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56CA14127C3234D001DC373 /* AppDelegate.swift */; };
 		B56CA14427C3234D001DC373 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56CA14327C3234D001DC373 /* SceneDelegate.swift */; };
 		B56CA14627C3234D001DC373 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56CA14527C3234D001DC373 /* ViewController.swift */; };
@@ -41,6 +42,7 @@
 		B52EC61D27C7582300C73E54 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		B52EC62127C863EE00C73E54 /* Players.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Players.swift; sourceTree = "<group>"; };
 		B52EC62327C8B0E300C73E54 /* Cards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cards.swift; sourceTree = "<group>"; };
+		B52EC62527C8C1CC00C73E54 /* Dealer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dealer.swift; sourceTree = "<group>"; };
 		B56CA13E27C3234D001DC373 /* PokerGameApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PokerGameApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B56CA14127C3234D001DC373 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B56CA14327C3234D001DC373 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -104,6 +106,7 @@
 				B56CA15727C486FA001DC373 /* Card.swift */,
 				B52EC62327C8B0E300C73E54 /* Cards.swift */,
 				B56CA15927C4B688001DC373 /* CardDeck.swift */,
+				B52EC62527C8C1CC00C73E54 /* Dealer.swift */,
 				B52EC61D27C7582300C73E54 /* Player.swift */,
 				B52EC62127C863EE00C73E54 /* Players.swift */,
 				B52EC60827C5DB4E00C73E54 /* PokerGame.swift */,
@@ -239,6 +242,7 @@
 				B56CA14627C3234D001DC373 /* ViewController.swift in Sources */,
 				B52EC61E27C7582300C73E54 /* Player.swift in Sources */,
 				B56CA14227C3234D001DC373 /* AppDelegate.swift in Sources */,
+				B52EC62627C8C1CC00C73E54 /* Dealer.swift in Sources */,
 				B56CA14427C3234D001DC373 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		B52EC61C27C679CB00C73E54 /* CardDeckTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52EC61B27C679CB00C73E54 /* CardDeckTest.swift */; };
 		B52EC61E27C7582300C73E54 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52EC61D27C7582300C73E54 /* Player.swift */; };
 		B52EC62227C863EE00C73E54 /* Players.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52EC62127C863EE00C73E54 /* Players.swift */; };
+		B52EC62427C8B0E300C73E54 /* Cards.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52EC62327C8B0E300C73E54 /* Cards.swift */; };
 		B56CA14227C3234D001DC373 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56CA14127C3234D001DC373 /* AppDelegate.swift */; };
 		B56CA14427C3234D001DC373 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56CA14327C3234D001DC373 /* SceneDelegate.swift */; };
 		B56CA14627C3234D001DC373 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56CA14527C3234D001DC373 /* ViewController.swift */; };
@@ -39,6 +40,7 @@
 		B52EC61B27C679CB00C73E54 /* CardDeckTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeckTest.swift; sourceTree = "<group>"; };
 		B52EC61D27C7582300C73E54 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		B52EC62127C863EE00C73E54 /* Players.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Players.swift; sourceTree = "<group>"; };
+		B52EC62327C8B0E300C73E54 /* Cards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cards.swift; sourceTree = "<group>"; };
 		B56CA13E27C3234D001DC373 /* PokerGameApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PokerGameApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B56CA14127C3234D001DC373 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B56CA14327C3234D001DC373 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 			isa = PBXGroup;
 			children = (
 				B56CA15727C486FA001DC373 /* Card.swift */,
+				B52EC62327C8B0E300C73E54 /* Cards.swift */,
 				B56CA15927C4B688001DC373 /* CardDeck.swift */,
 				B52EC61D27C7582300C73E54 /* Player.swift */,
 				B52EC62127C863EE00C73E54 /* Players.swift */,
@@ -231,6 +234,7 @@
 				B52EC62227C863EE00C73E54 /* Players.swift in Sources */,
 				B56CA15827C486FA001DC373 /* Card.swift in Sources */,
 				B52EC60927C5DB4E00C73E54 /* PokerGame.swift in Sources */,
+				B52EC62427C8B0E300C73E54 /* Cards.swift in Sources */,
 				B56CA15A27C4B688001DC373 /* CardDeck.swift in Sources */,
 				B56CA14627C3234D001DC373 /* ViewController.swift in Sources */,
 				B52EC61E27C7582300C73E54 /* Player.swift in Sources */,

--- a/PokerGameApp/PokerGameApp/Cards.swift
+++ b/PokerGameApp/PokerGameApp/Cards.swift
@@ -9,7 +9,6 @@ struct Cards: CustomStringConvertible{
     var description: String{
         return self.cards.description
     }
-    private var index = 0
     
     mutating func addCard(_ card: Card){
         self.cards.append(card)

--- a/PokerGameApp/PokerGameApp/Cards.swift
+++ b/PokerGameApp/PokerGameApp/Cards.swift
@@ -1,11 +1,15 @@
 import Foundation
 
-struct Cards{
-    
+struct Cards: CustomStringConvertible{
+  
     private var cards: [Card] = []
-    var currentCards: [Card]{
-        return self.cards
+    var count: Int{
+        return self.cards.count
     }
+    var description: String{
+        return self.cards.description
+    }
+    private var index = 0
     
     mutating func addCard(_ card: Card){
         self.cards.append(card)
@@ -14,4 +18,9 @@ struct Cards{
     mutating func removeOne()-> Card?{
         return self.cards.popLast()
     }
+    
+    func getIterator() -> IndexingIterator<[Card]>{
+        return self.cards.makeIterator()
+    }
+
 }

--- a/PokerGameApp/PokerGameApp/Cards.swift
+++ b/PokerGameApp/PokerGameApp/Cards.swift
@@ -11,7 +11,7 @@ struct Cards{
         self.cards.append(card)
     }
     
-    mutating func removeCard()-> Card?{
+    mutating func removeOne()-> Card?{
         return self.cards.popLast()
     }
 }

--- a/PokerGameApp/PokerGameApp/Cards.swift
+++ b/PokerGameApp/PokerGameApp/Cards.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct Cards{
+    
+    private var cards: [Card] = []
+    var currentCards: [Card]{
+        return self.cards
+    }
+    
+    mutating func addCard(_ card: Card){
+        self.cards.append(card)
+    }
+    
+    mutating func removeCard()-> Card?{
+        return self.cards.popLast()
+    }
+}

--- a/PokerGameApp/PokerGameApp/Dealer.swift
+++ b/PokerGameApp/PokerGameApp/Dealer.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+class Dealer: Player{
+    
+    init() {
+        super.init(name: "딜러")
+    }
+    
+    func takeOutAllNecessaryCards(deck: CardDeck, count: Int)->CardDeck{
+        var deckCopy = deck
+        for _ in 0..<count{
+            guard let card = deckCopy.removeOne() else { continue }
+            super.addCard(card)
+        }
+        return deckCopy
+    }
+}

--- a/PokerGameApp/PokerGameApp/Player.swift
+++ b/PokerGameApp/PokerGameApp/Player.swift
@@ -1,7 +1,10 @@
 import Foundation
 
 class Player: CustomStringConvertible{
-    var name: String
+    private var name: String
+    var playerName: String{
+        return self.name
+    }
     fileprivate (set) var cards: [Card] = []
     var description: String{
         return "\(name) \(cards)"

--- a/PokerGameApp/PokerGameApp/Player.swift
+++ b/PokerGameApp/PokerGameApp/Player.swift
@@ -25,7 +25,7 @@ class Dealer: Player{
         super.init(name: "딜러")
     }
     
-    func handOutCard(stud: Int)-> Card?{
+    func handOutCard()-> Card?{
         guard let card = self.cards.popLast() else { return nil }
         return card
     }

--- a/PokerGameApp/PokerGameApp/Player.swift
+++ b/PokerGameApp/PokerGameApp/Player.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class Player: CustomStringConvertible{
     private var name: String
-    var playerName: String{
+    var currentName: String{
         return self.name
     }
     fileprivate (set) var cards: [Card] = []

--- a/PokerGameApp/PokerGameApp/Player.swift
+++ b/PokerGameApp/PokerGameApp/Player.swift
@@ -25,7 +25,20 @@ class Dealer: Player{
         super.init(name: "딜러")
     }
     
-    func handOutCard()-> Card?{
+    func distributeCards(){
+        
+    }
+    
+    func takeOutAllNecessaryCards(deck: CardDeck, count: Int)->CardDeck{
+        var deckCopy = deck
+        for _ in 0..<count{
+            guard let card = deckCopy.removeOne() else { continue }
+            super.addCard(card)
+        }
+        return deckCopy
+    }
+    
+    func takeOutCard()-> Card?{
         guard let card = self.cards.popLast() else { return nil }
         return card
     }

--- a/PokerGameApp/PokerGameApp/Player.swift
+++ b/PokerGameApp/PokerGameApp/Player.swift
@@ -5,7 +5,7 @@ class Player: CustomStringConvertible{
     var currentName: String{
         return self.name
     }
-    fileprivate (set) var cards: Cards
+    private (set) var cards: Cards
     var description: String{
         return "\(name) \(cards)"
     }
@@ -17,22 +17,6 @@ class Player: CustomStringConvertible{
     
     func addCard(_ card: Card){
         self.cards.addCard(card)
-    }
-}
-
-class Dealer: Player{
-    
-    init() {
-        super.init(name: "딜러")
-    }
-    
-    func takeOutAllNecessaryCards(deck: CardDeck, count: Int)->CardDeck{
-        var deckCopy = deck
-        for _ in 0..<count{
-            guard let card = deckCopy.removeOne() else { continue }
-            super.addCard(card)
-        }
-        return deckCopy
     }
     
     func takeOutCard()-> Card?{

--- a/PokerGameApp/PokerGameApp/Player.swift
+++ b/PokerGameApp/PokerGameApp/Player.swift
@@ -36,7 +36,7 @@ class Dealer: Player{
     }
     
     func takeOutCard()-> Card?{
-        guard let card = self.cards.removeCard() else { return nil }
+        guard let card = self.cards.removeOne() else { return nil }
         return card
     }
 }

--- a/PokerGameApp/PokerGameApp/Player.swift
+++ b/PokerGameApp/PokerGameApp/Player.swift
@@ -5,28 +5,25 @@ class Player: CustomStringConvertible{
     var currentName: String{
         return self.name
     }
-    fileprivate (set) var cards: [Card] = []
+    fileprivate (set) var cards: Cards
     var description: String{
         return "\(name) \(cards)"
     }
     
     init(name: String){
         self.name = name
+        self.cards = Cards()
     }
     
     func addCard(_ card: Card){
-        self.cards.append(card)
+        self.cards.addCard(card)
     }
 }
 
 class Dealer: Player{
-
+    
     init() {
         super.init(name: "딜러")
-    }
-    
-    func distributeCards(){
-        
     }
     
     func takeOutAllNecessaryCards(deck: CardDeck, count: Int)->CardDeck{
@@ -39,7 +36,7 @@ class Dealer: Player{
     }
     
     func takeOutCard()-> Card?{
-        guard let card = self.cards.popLast() else { return nil }
+        guard let card = self.cards.removeCard() else { return nil }
         return card
     }
 }

--- a/PokerGameApp/PokerGameApp/Players.swift
+++ b/PokerGameApp/PokerGameApp/Players.swift
@@ -34,9 +34,11 @@ class Players: CustomStringConvertible{
         self.players[playerIndex].addCard(card)
     }
     
-    func getIterator(additionalPlayer: Player) -> IndexingIterator<[Player]>{
+    func getIterator(additionalPlayer: Player?) -> IndexingIterator<[Player]>{
         var playersCopy = self.players
-        playersCopy.append(additionalPlayer)
+        if let additionalPlayer = additionalPlayer{
+            playersCopy.append(additionalPlayer)
+        }
         return playersCopy.makeIterator()
     }
     

--- a/PokerGameApp/PokerGameApp/Players.swift
+++ b/PokerGameApp/PokerGameApp/Players.swift
@@ -4,9 +4,6 @@ class Players: CustomStringConvertible{
     
     private var randomNames = ["dale","eddy","jee","foucault","sol"]
     private var players: [Player] = []
-    var currentPlayers: [Player]{
-        return self.players
-    }
     private let numberOfPlayers: PokerGame.Count
     var count: Int{
         return players.count
@@ -35,6 +32,12 @@ class Players: CustomStringConvertible{
     
     func addCard(playerIndex: Int, card: Card){
         self.players[playerIndex].addCard(card)
+    }
+    
+    func getIterator(additionalPlayer: Player) -> IndexingIterator<[Player]>{
+        var playersCopy = self.players
+        playersCopy.append(additionalPlayer)
+        return playersCopy.makeIterator()
     }
     
 }

--- a/PokerGameApp/PokerGameApp/Players.swift
+++ b/PokerGameApp/PokerGameApp/Players.swift
@@ -8,7 +8,6 @@ class Players: CustomStringConvertible{
         return self.players
     }
     private let numberOfPlayers: PokerGame.Count
-    
     var count: Int{
         return players.count
     }

--- a/PokerGameApp/PokerGameApp/Players.swift
+++ b/PokerGameApp/PokerGameApp/Players.swift
@@ -7,7 +7,7 @@ class Players: CustomStringConvertible{
         return players.count
     }
     var description: String{
-        return players.reduce(into: "", { $0 += $1.description+"\n"})
+        return players.description
     }
     
     init(players: [Player]){

--- a/PokerGameApp/PokerGameApp/Players.swift
+++ b/PokerGameApp/PokerGameApp/Players.swift
@@ -2,7 +2,10 @@ import Foundation
 
 class Players: CustomStringConvertible{
     
+    private var randomNames = ["dale","eddy","jee","foucault","sol"]
     private (set) var players: [Player] = []
+    private let numberOfPlayers: PokerGame.Count
+    
     var count: Int{
         return players.count
     }
@@ -10,8 +13,18 @@ class Players: CustomStringConvertible{
         return players.description
     }
     
-    init(players: [Player]){
-        self.players = players
+    init(numberOfPlayers: PokerGame.Count){
+        self.randomNames.shuffle()
+        self.numberOfPlayers = numberOfPlayers
+        createPlayers()
+    }
+        
+    func createPlayers(){
+        for _ in 0..<numberOfPlayers.rawValue{
+            guard let playerName = randomNames.popLast() else { continue }
+            players.append(Player(name: playerName))
+        }
+
     }
     
     func addPlayer(_ player: Player){

--- a/PokerGameApp/PokerGameApp/Players.swift
+++ b/PokerGameApp/PokerGameApp/Players.swift
@@ -3,7 +3,10 @@ import Foundation
 class Players: CustomStringConvertible{
     
     private var randomNames = ["dale","eddy","jee","foucault","sol"]
-    private (set) var players: [Player] = []
+    private var players: [Player] = []
+    var currentPlayers: [Player]{
+        return self.players
+    }
     private let numberOfPlayers: PokerGame.Count
     
     var count: Int{

--- a/PokerGameApp/PokerGameApp/PokerGame.swift
+++ b/PokerGameApp/PokerGameApp/PokerGame.swift
@@ -17,7 +17,7 @@ class PokerGame: CustomStringConvertible{
     private (set) var stud: Stud
     private (set) var deck: CardDeck
     var dealer: Dealer
-    var players: Players?
+    var players: Players
     var description: String{
         return "\(players)\(dealer)"
     }
@@ -35,8 +35,6 @@ class PokerGame: CustomStringConvertible{
     }
     
     private func run(){
-        guard let players = self.players else { return }
-        
         if(isNumberOfCardsEnough()){
             self.deck = dealer.takeOutAllNecessaryCards(deck: self.deck, count: (players.count + 1) * stud.rawValue)
             distributeCards()
@@ -44,14 +42,10 @@ class PokerGame: CustomStringConvertible{
     }
     
     private func isNumberOfCardsEnough()-> Bool{
-        guard let players = self.players else { return false }
-        
         return deck.count >= (players.count + 1) * stud.rawValue
     }
     
     private func distributeCards(){
-        guard let players = self.players else { return }
-        
         for _ in 0..<stud.rawValue{
             for index in 0..<players.count{
                 guard let card = dealer.takeOutCard() else { continue }

--- a/PokerGameApp/PokerGameApp/PokerGame.swift
+++ b/PokerGameApp/PokerGameApp/PokerGame.swift
@@ -48,10 +48,7 @@ class PokerGame: CustomStringConvertible{
         guard let players = self.players else { return }
         
         if(isNumberOfCardsEnough()){
-            for _ in 0..<(players.count + 1) * stud.rawValue{
-                guard let card = deck.removeOne() else { continue }
-                dealer.addCard(card)
-            }
+            self.deck = dealer.takeOutAllNecessaryCards(deck: self.deck, count: (players.count + 1) * stud.rawValue)
             distributeCards()
         }
     }
@@ -67,7 +64,7 @@ class PokerGame: CustomStringConvertible{
         
         for _ in 0..<stud.rawValue{
             for index in 0..<players.count{
-                guard let card = dealer.handOutCard() else { continue }
+                guard let card = dealer.takeOutCard() else { continue }
                 players.addCard(playerIndex: index, card: card)
             }
         }

--- a/PokerGameApp/PokerGameApp/PokerGame.swift
+++ b/PokerGameApp/PokerGameApp/PokerGame.swift
@@ -67,7 +67,7 @@ class PokerGame: CustomStringConvertible{
         
         for _ in 0..<stud.rawValue{
             for index in 0..<players.count{
-                guard let card = dealer.handOutCard(stud: stud.rawValue) else { continue }
+                guard let card = dealer.handOutCard() else { continue }
                 players.addCard(playerIndex: index, card: card)
             }
         }

--- a/PokerGameApp/PokerGameApp/PokerGame.swift
+++ b/PokerGameApp/PokerGameApp/PokerGame.swift
@@ -13,7 +13,7 @@ class PokerGame: CustomStringConvertible{
         case seven = 7
     }
     
-    private var randomNames = ["dale","eddy","jee","foucault","sol"]
+    
     private (set) var stud: Stud
     private (set) var deck: CardDeck
     var dealer: Dealer
@@ -26,19 +26,9 @@ class PokerGame: CustomStringConvertible{
         self.stud = stud
         self.dealer = Dealer()
         self.deck = CardDeck()
-        self.players = createPlayers(numberOfPlayers: numberOfPlayers)
+        self.players = Players(numberOfPlayers: numberOfPlayers)
     }
-    
-    private func createPlayers(numberOfPlayers: Count)-> Players{
-        var players: [Player] = []
-        self.randomNames.shuffle()
-        for _ in 0..<numberOfPlayers.rawValue{
-            guard let playerName = randomNames.popLast() else { continue }
-            players.append(Player(name: playerName))
-        }
-        return Players(players: players)
-    }
-    
+        
     func start(){
         deck.shuffle()
         run()

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -82,17 +82,15 @@ class ViewController: UIViewController {
         var cardXPosition = initialXPosition
         var cardYPosition = CGFloat(studSelectionControl.center.y * 1.2)
         
-        var users: [Player] = game.players.currentPlayers
-        users.append(game.dealer)
-        
-        for user in users{
+        var playerIterator = game.players.getIterator(additionalPlayer: game.dealer)
+        while let player = playerIterator.next(){
             
-            let label = createUserNameLabel(name: user.currentName, x: initialXPosition, y: cardYPosition)
+            let label = createUserNameLabel(name: player.currentName, x: initialXPosition, y: cardYPosition)
             self.view.addSubview(label)
             self.labels.append(label)
             cardYPosition += label.frame.height
             
-            var cardIterator = user.cards.getIterator()
+            var cardIterator = player.cards.getIterator()
             while let card = cardIterator.next() {
                 guard let image = UIImage(named: "\(card.description)") else { continue }
                 let imageView = createCardImageView(image: image, x: cardXPosition, y: cardYPosition, width: cardWidth, height: cardHeight)

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -88,7 +88,7 @@ class ViewController: UIViewController {
         
         for user in users{
             
-            let label = createUserNameLabel(name: user.name, x: initialXPosition, y: cardYPosition)
+            let label = createUserNameLabel(name: user.playerName, x: initialXPosition, y: cardYPosition)
             self.view.addSubview(label)
             self.labels.append(label)
             cardYPosition += label.frame.height

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -72,7 +72,6 @@ class ViewController: UIViewController {
     func setAllImageViewsAndLabels(){
         
         guard let game = self.pokerGame else { return }
-        guard let players = game.players else { return }
         
         removePreviousCardImageViewsAndLabels()
         
@@ -83,7 +82,7 @@ class ViewController: UIViewController {
         var cardXPosition = initialXPosition
         var cardYPosition = CGFloat(studSelectionControl.center.y * 1.2)
         
-        var users: [Player] = players.currentPlayers
+        var users: [Player] = game.players.currentPlayers
         users.append(game.dealer)
         
         for user in users{

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -92,7 +92,8 @@ class ViewController: UIViewController {
             self.labels.append(label)
             cardYPosition += label.frame.height
             
-            for card in user.cards.currentCards{
+            var cardIterator = user.cards.getIterator()
+            while let card = cardIterator.next() {
                 guard let image = UIImage(named: "\(card.description)") else { continue }
                 let imageView = createCardImageView(image: image, x: cardXPosition, y: cardYPosition, width: cardWidth, height: cardHeight)
                 self.view.addSubview(imageView)

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -88,7 +88,7 @@ class ViewController: UIViewController {
         
         for user in users{
             
-            let label = createUserNameLabel(name: user.playerName, x: initialXPosition, y: cardYPosition)
+            let label = createUserNameLabel(name: user.currentName, x: initialXPosition, y: cardYPosition)
             self.view.addSubview(label)
             self.labels.append(label)
             cardYPosition += label.frame.height

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -93,7 +93,7 @@ class ViewController: UIViewController {
             self.labels.append(label)
             cardYPosition += label.frame.height
             
-            for card in user.cards{
+            for card in user.cards.currentCards{
                 guard let image = UIImage(named: "\(card.description)") else { continue }
                 let imageView = createCardImageView(image: image, x: cardXPosition, y: cardYPosition, width: cardWidth, height: cardHeight)
                 self.view.addSubview(imageView)

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -83,7 +83,7 @@ class ViewController: UIViewController {
         var cardXPosition = initialXPosition
         var cardYPosition = CGFloat(studSelectionControl.center.y * 1.2)
         
-        var users: [Player] = players.players
+        var users: [Player] = players.currentPlayers
         users.append(game.dealer)
         
         for user in users{

--- a/PokerGameApp/PokerGameAppTests/CardDeckTest.swift
+++ b/PokerGameApp/PokerGameAppTests/CardDeckTest.swift
@@ -22,7 +22,7 @@ class CardDeckTest: XCTestCase {
     func testRemoveOne(){
         deck.reset()
         XCTAssertNotNil(deck.removeOne())
-        XCTAssertEqual(deck.removeOne()!.suit.description, "♥︎")
+        XCTAssertEqual(deck.removeOne()!.suit.description, "h")
     }
     
     func testReset(){

--- a/PokerGameApp/PokerGameTest.swift
+++ b/PokerGameApp/PokerGameTest.swift
@@ -19,9 +19,9 @@ class PokerGameTest: XCTestCase {
     func testCardDistribution(){
         pokerGame.start()
         for player in pokerGame.players.currentPlayers{
-            XCTAssertEqual(player.cards.currentCards.count, pokerGame.stud.rawValue)
+            XCTAssertEqual(player.cards.count, pokerGame.stud.rawValue)
         }
-        XCTAssertEqual(pokerGame.dealer.cards.currentCards.count, pokerGame.stud.rawValue)
+        XCTAssertEqual(pokerGame.dealer.cards.count, pokerGame.stud.rawValue)
     }
 
 }

--- a/PokerGameApp/PokerGameTest.swift
+++ b/PokerGameApp/PokerGameTest.swift
@@ -12,16 +12,16 @@ class PokerGameTest: XCTestCase {
     
     
     func testInitialization(){
-        XCTAssertEqual(pokerGame.dealer.name, "딜러")
+        XCTAssertEqual(pokerGame.dealer.currentName, "딜러")
         XCTAssertEqual(pokerGame.players.count, 4)
     }
     
     func testCardDistribution(){
         pokerGame.start()
-        for player in pokerGame.players{
-            XCTAssertEqual(player.cards.count, pokerGame.stud.rawValue)
+        for player in pokerGame.players.currentPlayers{
+            XCTAssertEqual(player.cards.currentCards.count, pokerGame.stud.rawValue)
         }
-        XCTAssertEqual(pokerGame.dealer.cards.count, pokerGame.stud.rawValue)
+        XCTAssertEqual(pokerGame.dealer.cards.currentCards.count, pokerGame.stud.rawValue)
     }
 
 }

--- a/PokerGameApp/PokerGameTest.swift
+++ b/PokerGameApp/PokerGameTest.swift
@@ -18,7 +18,8 @@ class PokerGameTest: XCTestCase {
     
     func testCardDistribution(){
         pokerGame.start()
-        for player in pokerGame.players.currentPlayers{
+        var playerIterator = pokerGame.players.getIterator(additionalPlayer: nil)
+        while let player = playerIterator.next(){
             XCTAssertEqual(player.cards.count, pokerGame.stud.rawValue)
         }
         XCTAssertEqual(pokerGame.dealer.cards.count, pokerGame.stud.rawValue)


### PR DESCRIPTION
## 작업내용
- [x] PokerGame 클래스 리팩토링
- [x] Players 클래스 리팩토링
- [x] Player, Dealer 클래스 리팩토링  
- [x] Cards 클래스 생성  
    
## 학습키워드
- iterator
    
## 고민과 해결
### 1. Players, Cards 내부의 배열 private로 선언
- 상기 클래스 내부에 있는 배열 프로퍼티에 직접 접근할 수 없도록 private로 선언했습니다.
- 각각의 클래스에 별도의 메소드를 선언해서 배열에 요소를 넣거나 제거할 수 있도록 했습니다.
- 만약 ViewController와 같은 외부에서 내부에 있는 배열값을 순차적으로 순회하고자 할 경우에는 iterator을 리턴하는 메소드를 별도로 만들어 여기서 받은 iterator을 가지고 순회하도록 했습니다.
```swift
    //iterator 리턴
    func getIterator(additionalPlayer: Player?) -> IndexingIterator<[Player]>{
        var playersCopy = self.players
        if let additionalPlayer = additionalPlayer{
            playersCopy.append(additionalPlayer)
        }
        return playersCopy.makeIterator()
    }

    var playerIterator = game.players.getIterator(additionalPlayer: game.dealer)
    while let player = playerIterator.next(){
        //플레이어 순회
    }
```
    
### 2. Player 내부의 cards 객체배열 타입 프로퍼티를 private로 선언
- 기존에는 Player을 상속받은 Dealer 클래스가 사용하는 메소드 중 하나가 부모 클래스인 Player의 cards 프로퍼티에 직접 접근해야 했습니다.
- 이로 인해 cards를 fileprivate (set)으로 선언했지만, 이를 온전히 private로 선언하고자 Dealer에 있던 해당 메소드를 부모 클래스로 이동시켜서 Dealer이 부모 클래스의 프로퍼티에 접근하는 로직을 없앴습니다.
- 이후 Dealer 클래스 역시 별도의 Dealer.swift 파일로 이동시켰습니다.
    
### 3. Players를 생성하는 createPlayers() 메소드 로직을 Players 내부로 이동
- 기존에는 PokerGame 객체에서 createPlayers() 메소드를 실행시켜서 해당 메소드가 리턴하는 값으로 프로퍼티를 초기화했습니다.
- 아얘 createPlayers를 Players 내부로 이동시켜서 내부적으로 필요한 프로퍼티를 초기화하는 식으로 수정했습니다.
    
## 질문거리
- 특정 클래스가 가진 배열 프로퍼티를 외부에서 순차적으로 순회하고자 할 경우에, 해당 프로퍼티에 직접 접근하지 않고 어떻게 순회할 수 있을까 고민하다가 내린 결정이 iterator을 만들어서 리턴하고, 외부에서는 리턴받은 iterator을 사용해서 순회하는 것이었습니다. 이게 올바른 접근인 지 헷갈려서 질문드리고 싶습니다.
- 제가 수업시간에 이해하기로는 프로퍼티를 private로 사용하는 제일 큰 목적은 __외부에서 여기에 직접 접근해서 값을 수정하는 것을 방지__ 하는 데 있다고 생각했습니다. 이럴 경우에 swift에서는 private (set)으로 선언해서 사실상 해당 프로퍼티를 read-only한 특징을 가지도록 하는 것으로 알고 있는데 이런 식으로 읽기(get)만 가능한 상태인 프로퍼티 배열에 직접 접근하는 것은 왜 지양되는 지 궁금합니다!