### PR TITLE
[Jed] Step 5-2 : 리팩토링

### DIFF
--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct CardDeck{
+class CardDeck{
     
     private var deck: [Card] = []
     var count: Int{
@@ -11,7 +11,7 @@ struct CardDeck{
         reset()
     }
     
-    mutating func shuffle(){
+    func shuffle(){
         for startIndex in 0..<deck.count-1{
             let randomIndex = Int.random(in: startIndex..<deck.count)
             let temp = deck[startIndex]
@@ -20,11 +20,11 @@ struct CardDeck{
         }
     }
     
-    mutating func removeOne()-> Card?{
+    func removeOne()-> Card?{
         return deck.popLast()
     }
     
-    mutating func reset(){
+    func reset(){
         self.deck = []
         for suit in Card.Suit.allCases{
             for number in Card.Number.allCases{

--- a/PokerGameApp/PokerGameApp/Dealer.swift
+++ b/PokerGameApp/PokerGameApp/Dealer.swift
@@ -2,16 +2,18 @@ import Foundation
 
 class Dealer: Player{
     
-    init() {
+    private var deck: CardDeck
+    
+    init(deck: CardDeck) {
+        self.deck = deck
         super.init(name: "딜러")
     }
     
-    func takeOutAllNecessaryCards(deck: CardDeck, count: Int)->CardDeck{
-        var deckCopy = deck
+    func takeOutAllNecessaryCards(count: Int){
+  
         for _ in 0..<count{
-            guard let card = deckCopy.removeOne() else { continue }
+            guard let card = self.deck.removeOne() else { continue }
             super.addCard(card)
         }
-        return deckCopy
     }
 }

--- a/PokerGameApp/PokerGameApp/Dealer.swift
+++ b/PokerGameApp/PokerGameApp/Dealer.swift
@@ -9,11 +9,8 @@ class Dealer: Player{
         super.init(name: "딜러")
     }
     
-    func takeOutAllNecessaryCards(count: Int){
-  
-        for _ in 0..<count{
-            guard let card = self.deck.removeOne() else { continue }
-            super.addCard(card)
-        }
+    func takeOutCard()-> Card?{
+        guard let card = self.deck.removeOne() else { return nil }
+        return card
     }
 }

--- a/PokerGameApp/PokerGameApp/Player.swift
+++ b/PokerGameApp/PokerGameApp/Player.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 class Player: CustomStringConvertible{
+    
     private var name: String
     var currentName: String{
         return self.name

--- a/PokerGameApp/PokerGameApp/Player.swift
+++ b/PokerGameApp/PokerGameApp/Player.swift
@@ -5,7 +5,7 @@ class Player: CustomStringConvertible{
     var currentName: String{
         return self.name
     }
-    private (set) var cards: Cards
+    private var cards: Cards
     var description: String{
         return "\(name) \(cards)"
     }

--- a/PokerGameApp/PokerGameApp/Player.swift
+++ b/PokerGameApp/PokerGameApp/Player.swift
@@ -19,8 +19,8 @@ class Player: CustomStringConvertible{
         self.cards.addCard(card)
     }
     
-    func takeOutCard()-> Card?{
-        guard let card = self.cards.removeOne() else { return nil }
-        return card
+    func getCardsIterator() -> IndexingIterator<[Card]>{
+        return self.cards.getIterator()
     }
+
 }

--- a/PokerGameApp/PokerGameApp/Player.swift
+++ b/PokerGameApp/PokerGameApp/Player.swift
@@ -6,6 +6,9 @@ class Player: CustomStringConvertible{
         return self.name
     }
     private var cards: Cards
+    var cardsCount: Int{
+        return self.cards.count
+    }
     var description: String{
         return "\(name) \(cards)"
     }

--- a/PokerGameApp/PokerGameApp/Players.swift
+++ b/PokerGameApp/PokerGameApp/Players.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 class Players: CustomStringConvertible{
-    
-    private var randomNames = ["dale","eddy","jee","foucault","sol"]
     private var players: [Player] = []
     var count: Int{
         return players.count
@@ -11,18 +9,12 @@ class Players: CustomStringConvertible{
         return players.description
     }
     
-    init(numberOfPlayers: Int){
-        self.randomNames.shuffle()
-        createPlayers(numberOfPlayers: numberOfPlayers)
-    }
-        
-    func createPlayers(numberOfPlayers: Int){
-        for _ in 0..<numberOfPlayers{
-            guard let playerName = randomNames.popLast() else { continue }
-            players.append(Player(name: playerName))
+    init(creatingLoop: ()->[Player]){
+        for player in creatingLoop(){
+            self.players.append(player)
         }
     }
-    
+            
     func addPlayer(_ player: Player){
         self.players.append(player)
     }

--- a/PokerGameApp/PokerGameApp/Players.swift
+++ b/PokerGameApp/PokerGameApp/Players.swift
@@ -4,7 +4,6 @@ class Players: CustomStringConvertible{
     
     private var randomNames = ["dale","eddy","jee","foucault","sol"]
     private var players: [Player] = []
-    private let numberOfPlayers: PokerGame.Count
     var count: Int{
         return players.count
     }
@@ -12,18 +11,16 @@ class Players: CustomStringConvertible{
         return players.description
     }
     
-    init(numberOfPlayers: PokerGame.Count){
+    init(numberOfPlayers: Int){
         self.randomNames.shuffle()
-        self.numberOfPlayers = numberOfPlayers
-        createPlayers()
+        createPlayers(numberOfPlayers: numberOfPlayers)
     }
         
-    func createPlayers(){
-        for _ in 0..<numberOfPlayers.rawValue{
+    func createPlayers(numberOfPlayers: Int){
+        for _ in 0..<numberOfPlayers{
             guard let playerName = randomNames.popLast() else { continue }
             players.append(Player(name: playerName))
         }
-
     }
     
     func addPlayer(_ player: Player){

--- a/PokerGameApp/PokerGameApp/Players.swift
+++ b/PokerGameApp/PokerGameApp/Players.swift
@@ -1,6 +1,20 @@
 import Foundation
 
 class Players: CustomStringConvertible{
+    
+    internal enum Count: Int, CaseIterable{
+        case two = 2
+        case three = 3
+        case four = 4
+        
+        func creatingLoop(loop: ()->Void){
+            for _ in 0..<self.rawValue{
+                loop()
+            }
+        }
+    }
+    
+    private var randomNames = ["dale","eddy","jee","foucault","sol"]
     private var players: [Player] = []
     var count: Int{
         return players.count
@@ -9,9 +23,14 @@ class Players: CustomStringConvertible{
         return players.description
     }
     
-    init(creatingLoop: ()->[Player]){
-        for player in creatingLoop(){
-            self.players.append(player)
+    init(numberOfPlayers: Count){
+        createPlayers(numberOfPlayers: numberOfPlayers)
+    }
+    
+    func createPlayers(numberOfPlayers: Count){
+        numberOfPlayers.creatingLoop {
+            guard let playerName = randomNames.popLast() else { return }
+            players.append(Player(name: playerName))
         }
     }
             

--- a/PokerGameApp/PokerGameApp/Players.swift
+++ b/PokerGameApp/PokerGameApp/Players.swift
@@ -30,10 +30,6 @@ class Players: CustomStringConvertible{
         self.players.append(player)
     }
     
-    func addCard(playerIndex: Int, card: Card){
-        self.players[playerIndex].addCard(card)
-    }
-    
     func getIterator(additionalPlayer: Player?) -> IndexingIterator<[Player]>{
         var playersCopy = self.players
         if let additionalPlayer = additionalPlayer{

--- a/PokerGameApp/PokerGameApp/PokerGame.swift
+++ b/PokerGameApp/PokerGameApp/PokerGame.swift
@@ -1,12 +1,6 @@
 import Foundation
 
-class PokerGame: CustomStringConvertible{
-    
-    internal enum Count: Int, CaseIterable{
-        case two = 2
-        case three = 3
-        case four = 4
-    }
+class PokerGame: CustomStringConvertible{    
     
     internal enum Stud: Int, CaseIterable{
         case five = 5
@@ -21,20 +15,11 @@ class PokerGame: CustomStringConvertible{
         return "\(players)\(dealer)"
     }
     
-    init(numberOfPlayers: Count, stud: Stud){
+    init(numberOfPlayers: Players.Count, stud: Stud){
         self.stud = stud
         self.deck = CardDeck()
         self.dealer = Dealer(deck: self.deck)
-
-        var randomNames = ["dale","eddy","jee","foucault","sol"]
-        self.players = Players(creatingLoop: {
-            var players: [Player] = []
-            for _ in 0..<numberOfPlayers.rawValue{
-                guard let playerName = randomNames.popLast() else { continue }
-                players.append(Player(name: playerName))
-            }
-            return players
-        })
+        self.players = Players(numberOfPlayers: numberOfPlayers)
     }
         
     func start(){

--- a/PokerGameApp/PokerGameApp/PokerGame.swift
+++ b/PokerGameApp/PokerGameApp/PokerGame.swift
@@ -26,7 +26,7 @@ class PokerGame: CustomStringConvertible{
         self.stud = stud
         self.deck = CardDeck()
         self.dealer = Dealer(deck: self.deck)
-        self.players = Players(numberOfPlayers: numberOfPlayers)
+        self.players = Players(numberOfPlayers: numberOfPlayers.rawValue)
     }
         
     func start(){

--- a/PokerGameApp/PokerGameApp/PokerGame.swift
+++ b/PokerGameApp/PokerGameApp/PokerGame.swift
@@ -13,7 +13,6 @@ class PokerGame: CustomStringConvertible{
         case seven = 7
     }
     
-    
     private (set) var stud: Stud
     private (set) var deck: CardDeck
     var dealer: Dealer
@@ -26,7 +25,16 @@ class PokerGame: CustomStringConvertible{
         self.stud = stud
         self.deck = CardDeck()
         self.dealer = Dealer(deck: self.deck)
-        self.players = Players(numberOfPlayers: numberOfPlayers.rawValue)
+
+        var randomNames = ["dale","eddy","jee","foucault","sol"]
+        self.players = Players(creatingLoop: {
+            var players: [Player] = []
+            for _ in 0..<numberOfPlayers.rawValue{
+                guard let playerName = randomNames.popLast() else { continue }
+                players.append(Player(name: playerName))
+            }
+            return players
+        })
     }
         
     func start(){

--- a/PokerGameApp/PokerGameApp/PokerGame.swift
+++ b/PokerGameApp/PokerGameApp/PokerGame.swift
@@ -24,8 +24,8 @@ class PokerGame: CustomStringConvertible{
     
     init(numberOfPlayers: Count, stud: Stud){
         self.stud = stud
-        self.dealer = Dealer()
         self.deck = CardDeck()
+        self.dealer = Dealer(deck: self.deck)
         self.players = Players(numberOfPlayers: numberOfPlayers)
     }
         
@@ -36,7 +36,6 @@ class PokerGame: CustomStringConvertible{
     
     private func run(){
         if(isNumberOfCardsEnough()){
-            self.deck = dealer.takeOutAllNecessaryCards(deck: self.deck, count: (players.count + 1) * stud.rawValue)
             distributeCards()
         }
     }
@@ -46,10 +45,12 @@ class PokerGame: CustomStringConvertible{
     }
     
     private func distributeCards(){
+        
         for _ in 0..<stud.rawValue{
-            for index in 0..<players.count{
+            var playerIterator = self.players.getIterator(additionalPlayer: self.dealer)
+            while let player = playerIterator.next(){
                 guard let card = dealer.takeOutCard() else { continue }
-                players.addCard(playerIndex: index, card: card)
+                player.addCard(card)
             }
         }
     }

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -90,7 +90,7 @@ class ViewController: UIViewController {
             self.labels.append(label)
             cardYPosition += label.frame.height
             
-            var cardIterator = player.cards.getIterator()
+            var cardIterator = player.getCardsIterator()
             while let card = cardIterator.next() {
                 guard let image = UIImage(named: "\(card.description)") else { continue }
                 let imageView = createCardImageView(image: image, x: cardXPosition, y: cardYPosition, width: cardWidth, height: cardHeight)

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -43,8 +43,8 @@ class ViewController: UIViewController {
         playerCountSelectionControl.selectedSegmentTintColor = UIColor.lightText
         playerCountSelectionControl.center.x = self.view.center.x
         playerCountSelectionControl.center.y = self.view.center.y * CGFloat(0.2)
-        for index in 0..<PokerGame.Count.allCases.count{
-            playerCountSelectionControl.setTitle("\(PokerGame.Count.allCases[index].rawValue)명", forSegmentAt: index)
+        for index in 0..<Players.Count.allCases.count{
+            playerCountSelectionControl.setTitle("\(Players.Count.allCases[index].rawValue)명", forSegmentAt: index)
         }
     }
     
@@ -59,7 +59,7 @@ class ViewController: UIViewController {
     }
     
     func setPokerGame(){
-        let selectedCount = PokerGame.Count.allCases[playerCountSelectionControl.selectedSegmentIndex]
+        let selectedCount = Players.Count.allCases[playerCountSelectionControl.selectedSegmentIndex]
         let selectedStud = PokerGame.Stud.allCases[studSelectionControl.selectedSegmentIndex]
         
         self.pokerGame = PokerGame(numberOfPlayers: selectedCount, stud: selectedStud)

--- a/PokerGameApp/PokerGameTest.swift
+++ b/PokerGameApp/PokerGameTest.swift
@@ -20,9 +20,9 @@ class PokerGameTest: XCTestCase {
         pokerGame.start()
         var playerIterator = pokerGame.players.getIterator(additionalPlayer: nil)
         while let player = playerIterator.next(){
-            XCTAssertEqual(player.cards.count, pokerGame.stud.rawValue)
+            XCTAssertEqual(player.cardsCount, pokerGame.stud.rawValue)
         }
-        XCTAssertEqual(pokerGame.dealer.cards.count, pokerGame.stud.rawValue)
+        XCTAssertEqual(pokerGame.dealer.cardsCount, pokerGame.stud.rawValue)
     }
 
 }

--- a/PokerGameApp/PokerGameTest.swift
+++ b/PokerGameApp/PokerGameTest.swift
@@ -6,7 +6,7 @@ class PokerGameTest: XCTestCase {
     private var pokerGame: PokerGame!
     
     override func setUp(){
-        pokerGame = PokerGame(numberOfPlayers: PokerGame.Count.four, stud: PokerGame.Stud.five)
+        pokerGame = PokerGame(numberOfPlayers: Players.Count.four, stud: PokerGame.Stud.five)
         super.setUp()
     }
     


### PR DESCRIPTION
### 작업 내용
- [x] Player 클래스 내에서 PokerGame의 하위타입을 참조하던 부분 수정
- [x] 카드를 빼는 행위가 정의된 takeOutCard 메소드를 Player에서 자식클래스인 Dealer로 이동
- [x] 사실상 불필요한 행위인  Dealer 클래스 내부의 takeOutAllNecessaryCards 메소드 제거
- [x] CardDeck 구조체를 클래스로 변경 후, PokerGame과 Dealer 클래스가 참조값을 공유하도록 수정
    
### 고민과 해결
#### 1. Player 클래스 내에서 PokerGame.Count 참조타입을 사용하던 부분 수정
- PokerGame.Count가 아닌 Int 타입을 사용하도록 수정했습니다.
- PokerGame에서 Player을 초기화할 때도 Player.Count.rawValue를 넘기도록 수정했습니다.
- 어차피 PokerGame이라는 외부에서 열거형을 통해 정해진 Int값을 사용하기 때문에, Player 생성자 파라미터에서 Int 타입으로 받더라도 미리 정해진 case 중 하나만 들어올 것이므로 플레이어의 수를 정의하기 위한 별도의 타입 선언을 하지 않아도 문제 없다고 판단했습니다! 
    
#### 2. PokerGame 시작 시, 딜러가 카드 덱에서 카드를 가져와서 플레이어에게 나눠주던 로직을 좀 더 간소화
- 기존에는 카드 덱에 있던 52장의 카드 중, 플레이어에게 나눠줄 모든 카드를 우선 딜러가 가져온 후 다시 여기서 플레이어에게 1장씩 나눠주는 식으로 구현했습니다.
- 하지만 어차피 결과적으로 덱에 있는 카드를 1장씩 나눠주는 행위인데 굳이 딜러가 나눠줄 카드를 우선 가져오는 행위가 비효율적이라 판단했습니다.
- 따라서 위의 행위를 수행하던 takeOutAllNecessAryCards라는 Dealer 내부에 있던 메소드를 우선 제거한 후, Player 클래스에 있던 카드 덱에서 카드를 한장씩 빼오는 takeOutCard 메소드를 Dealer로 옮겨서, PokerGame의 distributeCards() 메소드 내부에서는 결과적으로 Dealer.takeOutCard()가 리턴하는 카드를 플레이어에게 넘기는 식으로 수정했습니다.
    - 이를 위해 또한 PokerGame과 Dealer이 공통으로 CardDeck을 관리하는 것이 낫겠나고 판단했습니다.
    - CardDeck을 구조체로 구현했던 것을 클래스로 변경한 후 Dealer에 CardDeck 타입 프로퍼티를 추가해서 PokerGame과 Dealer이 공통의 참조값을 바라보도록 수정했습니다.
    
#### 3.Player.cards 프로퍼티 완전한 private로 변경
- 다시 살펴보니 cards 프로퍼티가 private (set)으로 되어 있어서 private으로 수정했습니다.
- 외부에서 Player 내부의 카드의 수를 가져와야 할 필요가 있기에 별도로 카드 배열의 길이를 리턴하는 cardsCount 프로퍼티를 선언해서 이걸 사용하도록 수정했습니다.