### PR TITLE
[푸코] Step07 - 하위 뷰로 배분

### DIFF
--- a/PockerGameApp/PockerGameApp.xcodeproj/project.pbxproj
+++ b/PockerGameApp/PockerGameApp.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		D26BD12C27C47169001D0AD4 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26BD12B27C47169001D0AD4 /* Card.swift */; };
 		D26BD13027C4B334001D0AD4 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26BD12F27C4B334001D0AD4 /* CardDeck.swift */; };
 		D276C6C527C764BC007C9960 /* InGamePlayers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D276C6C427C764BC007C9960 /* InGamePlayers.swift */; };
+		D27AC52727CDC04E00F18460 /* PlayersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27AC52627CDC04E00F18460 /* PlayersViewController.swift */; };
+		D27AC52927CDC53400F18460 /* DealerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27AC52827CDC53400F18460 /* DealerViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +51,8 @@
 		D26BD12B27C47169001D0AD4 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		D26BD12F27C4B334001D0AD4 /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
 		D276C6C427C764BC007C9960 /* InGamePlayers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InGamePlayers.swift; sourceTree = "<group>"; };
+		D27AC52627CDC04E00F18460 /* PlayersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayersViewController.swift; sourceTree = "<group>"; };
+		D27AC52827CDC53400F18460 /* DealerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DealerViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,6 +106,8 @@
 				D267E90427C31E90009A2EA3 /* AppDelegate.swift */,
 				D267E90627C31E90009A2EA3 /* SceneDelegate.swift */,
 				D267E90827C31E90009A2EA3 /* ViewController.swift */,
+				D27AC52627CDC04E00F18460 /* PlayersViewController.swift */,
+				D27AC52827CDC53400F18460 /* DealerViewController.swift */,
 				D267E90A27C31E90009A2EA3 /* Main.storyboard */,
 				D267E90D27C31E91009A2EA3 /* Assets.xcassets */,
 				D267E90F27C31E91009A2EA3 /* LaunchScreen.storyboard */,
@@ -235,12 +241,14 @@
 				D267E90927C31E90009A2EA3 /* ViewController.swift in Sources */,
 				D260D7AB27C600D900855862 /* PockerGame.swift in Sources */,
 				D26BD13027C4B334001D0AD4 /* CardDeck.swift in Sources */,
+				D27AC52727CDC04E00F18460 /* PlayersViewController.swift in Sources */,
 				D267E90527C31E90009A2EA3 /* AppDelegate.swift in Sources */,
 				D276C6C527C764BC007C9960 /* InGamePlayers.swift in Sources */,
 				D260D7A727C5D19500855862 /* Dealer.swift in Sources */,
 				D260D7A527C5CF9B00855862 /* Player.swift in Sources */,
 				D267E90727C31E90009A2EA3 /* SceneDelegate.swift in Sources */,
 				D26BD12C27C47169001D0AD4 /* Card.swift in Sources */,
+				D27AC52927CDC53400F18460 /* DealerViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PockerGameApp/PockerGameApp/Base.lproj/Main.storyboard
+++ b/PockerGameApp/PockerGameApp/Base.lproj/Main.storyboard
@@ -11,7 +11,7 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="PockerGameApp" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="main" id="BYZ-38-t0r" customClass="ViewController" customModule="PockerGameApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -30,7 +30,7 @@
                                 </connections>
                             </segmentedControl>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="0uu-zC-xJn">
-                                <rect key="frame" x="120" y="83" width="150" height="32"/>
+                                <rect key="frame" x="137" y="83" width="116" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
                                 <segments>
@@ -43,6 +43,20 @@
                                     <action selector="entriesControllClick:" destination="BYZ-38-t0r" eventType="valueChanged" id="q0F-Ux-TQ8"/>
                                 </connections>
                             </segmentedControl>
+                            <containerView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6L3-fl-qlU" userLabel="PlayerView">
+                                <rect key="frame" x="0.0" y="130" width="390" height="480"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                <connections>
+                                    <segue destination="avW-CZ-SUu" kind="embed" id="mwH-ci-AjS"/>
+                                </connections>
+                            </containerView>
+                            <containerView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3ir-Bs-2si" userLabel="DealerView">
+                                <rect key="frame" x="0.0" y="610" width="390" height="105"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                <connections>
+                                    <segue destination="vVy-Ru-UxN" kind="embed" id="1bl-GD-tM2"/>
+                                </connections>
+                            </containerView>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vVZ-UZ-n1V">
                                 <rect key="frame" x="191" y="768" width="100" height="31"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -74,6 +88,36 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="7.6923076923076916" y="67.535545023696685"/>
+        </scene>
+        <!--Players View Controller-->
+        <scene sceneID="7OL-Bx-Vng">
+            <objects>
+                <viewController storyboardIdentifier="PlayersViewController" id="avW-CZ-SUu" customClass="PlayersViewController" customModule="PockerGameApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="FvP-ek-VZF">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="480"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="bGJ-C8-tmo"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="OCJ-b5-Apn" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="695" y="1"/>
+        </scene>
+        <!--Dealer View Controller-->
+        <scene sceneID="2l4-P5-EPG">
+            <objects>
+                <viewController storyboardIdentifier="DealerViewController" id="vVy-Ru-UxN" customClass="DealerViewController" customModule="PockerGameApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="2I8-Es-YYX">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="105"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="DYJ-j6-VAp"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="GUu-fB-Hv8" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="694" y="317"/>
         </scene>
     </scenes>
     <resources>

--- a/PockerGameApp/PockerGameApp/Data/InGamePlayers.swift
+++ b/PockerGameApp/PockerGameApp/Data/InGamePlayers.swift
@@ -46,7 +46,7 @@ struct InGamePlayers{
     }
     
     init(entry: PockerGame.Entries){
-        for _ in 0..<entry.caseNumber{
+        for _ in 0..<entry.caseNumber(){
             players.append(Player(randomName: String.makePlayerName()))
         }
     }

--- a/PockerGameApp/PockerGameApp/Data/PockerGame.swift
+++ b/PockerGameApp/PockerGameApp/Data/PockerGame.swift
@@ -101,34 +101,22 @@ class PockerGame{
         
     }
     
-    enum Variants: CaseIterable{
-        case fiveCardStud
-        case sevenCardStud
+    enum Variants: Int, CaseIterable{
+        case fiveCardStud = 5
+        case sevenCardStud = 7
         
-        var caseNumber: Int{
-            switch self {
-            case .fiveCardStud:
-                return 5
-            case .sevenCardStud:
-                return 7
-            }
+        func caseNumber() -> Int{
+            return self.rawValue
         }
     }
     
-    enum Entries: CaseIterable{
-        case two
-        case three
-        case four
+    enum Entries: Int, CaseIterable{
+        case two = 2
+        case three = 3
+        case four = 4
         
-        var caseNumber: Int{
-            switch self {
-            case .two:
-                return 2
-            case .three:
-                return 3
-            case .four:
-                return 4
-            }
+        func caseNumber() -> Int{
+            return self.rawValue
         }
     }
 }

--- a/PockerGameApp/PockerGameApp/DealerViewController.swift
+++ b/PockerGameApp/PockerGameApp/DealerViewController.swift
@@ -1,0 +1,123 @@
+//
+//  DelaerViewController.swift
+//  PockerGameApp
+//
+//  Created by juntaek.oh on 2022/03/01.
+//
+
+import UIKit
+
+class DealerViewController: UIViewController {
+    private var labelViews: [UILabel] = []
+    private var stackViews: [UIStackView] = []
+    
+    private var dealer: Dealer?
+    private var variant = PockerGame.Variants.fiveCardStud
+    private var entries = PockerGame.Entries.two
+    private var imageViewsIndex = 0
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        if let pattern = UIImage(named: "bg_pattern"){
+            self.view.backgroundColor = UIColor(patternImage: pattern)
+        }
+        
+        addLabelStackView()
+    }
+    
+    func getDealerInstance(dealer: Dealer){
+        self.dealer = dealer
+    }
+    
+    func getVariantValue(variant: PockerGame.Variants){
+        self.variant = variant
+    }
+    
+    func getEntriesValue(entries: PockerGame.Entries){
+        self.entries = entries
+    }
+    
+    func makeViews(){
+        guard let dealer = dealer else {
+            return
+        }
+
+        let frameX: Double = 30
+        var frameY: Double = 0
+        let stackViewWidth: Double = 330
+        let stackViewHeight: Double = 50 * 1.5
+        
+        let label = UILabel(frame: CGRect(x: frameX, y: frameY, width: 120, height: 30))
+        label.text = dealer.role
+        label.textColor = .white
+        label.font = UIFont(name: "System", size: 21)
+        self.labelViews.append(label)
+        self.view.addSubview(label)
+        
+        frameY += 30
+        
+        let stackView = UIStackView(frame: CGRect(x: frameX, y: frameY, width: stackViewWidth, height: stackViewHeight))
+        stackView.restorationIdentifier = dealer.role
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+        stackView.contentMode = .scaleAspectFit
+        stackView.backgroundColor = .white
+        makeImageView(stackView: stackView)
+        self.stackViews.append(stackView)
+        self.view.addSubview(stackView)
+    }
+    
+    func makeImageView(stackView: UIStackView){
+        for _ in 0..<variant.caseNumber(){
+            let imageView = UIImageView()
+            stackView.addArrangedSubview(imageView)
+        }
+    }
+
+    func makeUIImage(){
+        guard let card = dealer?.showMyCards().last else{
+            return
+        }
+        
+        let image = UIImage(named: "\(card.description)")
+        
+        self.view.subviews.forEach{ view in
+            guard let stackView = view as? UIStackView else{
+                return
+            }
+            
+            if stackView.restorationIdentifier == dealer?.role, let imageView = stackView.subviews[imageViewsIndex] as? UIImageView{
+                imageView.image = image
+            } else{
+                return
+            }
+        }
+        
+        imageViewsIndex += 1
+    }
+    
+    func addLabelStackView(){
+        makeViews()
+        labelViews.forEach{ label in
+            self.view.addSubview(label)
+        }
+        stackViews.forEach{ stack in
+            self.view.addSubview(stack)
+        }
+    }
+    
+    func removeLabelStackView(){
+        self.imageViewsIndex = 0
+        
+        labelViews.forEach{ label in
+            label.removeFromSuperview()
+        }
+        stackViews.forEach{ stack in
+            stack.removeFromSuperview()
+        }
+        
+        labelViews.removeAll()
+        stackViews.removeAll()
+    }
+}

--- a/PockerGameApp/PockerGameApp/PlayersViewController.swift
+++ b/PockerGameApp/PockerGameApp/PlayersViewController.swift
@@ -1,0 +1,129 @@
+//
+//  PlayersViewController.swift
+//  PockerGameApp
+//
+//  Created by juntaek.oh on 2022/03/01.
+//
+
+import UIKit
+
+class PlayersViewController: UIViewController {
+    private var labelViews: [UILabel] = []
+    private var stackViews: [UIStackView] = []
+    
+    private var players: InGamePlayers?
+    private var variant = PockerGame.Variants.fiveCardStud
+    private var entries = PockerGame.Entries.two
+    private var imageViewsIndex = 0
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        if let pattern = UIImage(named: "bg_pattern"){
+            self.view.backgroundColor = UIColor(patternImage: pattern)
+        }
+        
+        addLabelStackView()
+    }
+    
+    func getPlayersInstance(players: InGamePlayers){
+        self.players = players
+    }
+    
+    func getVariantValue(variant: PockerGame.Variants){
+        self.variant = variant
+    }
+    
+    func getEntriesValue(entries: PockerGame.Entries){
+        self.entries = entries
+    }
+    
+    func makeViews(){
+        guard let players = players?.showPlayers() else{
+            return
+        }
+
+        let frameX: Double = 30
+        var frameY: Double = 0
+        let stackViewWidth: Double = 330
+        let stackViewHeight: Double = 50 * 1.5
+        
+        players.forEach{ player in
+            let label = UILabel(frame: CGRect(x: frameX, y: frameY, width: 120, height: 30))
+            label.text = "Player : \(player.name)"
+            label.textColor = .white
+            self.labelViews.append(label)
+            
+            frameY += 30
+            
+            let stackView = UIStackView(frame: CGRect(x: frameX, y: frameY, width: stackViewWidth, height: stackViewHeight))
+            stackView.restorationIdentifier = player.name
+            stackView.axis = .horizontal
+            stackView.distribution = .fillEqually
+            stackView.contentMode = .scaleAspectFit
+            stackView.backgroundColor = .white
+            makeImageView(stackView: stackView)
+            self.stackViews.append(stackView)
+            
+            frameY += stackViewHeight + 20
+        }
+    }
+    
+    func makeImageView(stackView: UIStackView){
+        for _ in 0..<variant.caseNumber(){
+            let imageView = UIImageView()
+            stackView.addArrangedSubview(imageView)
+        }
+    }
+    
+    func makeUIImage(){
+        guard let players = players?.showPlayers() else{
+            return
+        }
+
+        players.forEach{ player in
+            guard let card = player.showMyCards().last else{
+                return
+            }
+            let image = UIImage(named: "\(card.description)")
+            
+            self.view.subviews.forEach{ view in
+                guard let stackView = view as? UIStackView else{
+                    return
+                }
+                
+                if stackView.restorationIdentifier == player.name, let imageView = stackView.subviews[imageViewsIndex] as? UIImageView{
+                    imageView.image = image
+                } else{
+                    return
+                }
+            }
+        }
+    
+        imageViewsIndex += 1
+    }
+    
+    func addLabelStackView(){
+        makeViews()
+        labelViews.forEach{ label in
+            self.view.addSubview(label)
+        }
+        stackViews.forEach{ stack in
+            self.view.addSubview(stack)
+        }
+    }
+    
+    func removeLabelStackView(){
+        self.imageViewsIndex = 0
+        
+        labelViews.forEach{ label in
+            label.removeFromSuperview()
+        }
+        stackViews.forEach{ stack in
+            stack.removeFromSuperview()
+        }
+        
+        labelViews.removeAll()
+        stackViews.removeAll()
+    }
+}


### PR DESCRIPTION
## 작업 목록
- [x] ViewContainer 추가 및 속성 설정
- [x] Players 매칭 ViewController 구현
- [x] Dealer 매칭 ViewController 구현

## 고민과 해결
- 하위 뷰의 ViewController의 접근 방식을 몰라, Players와 Dealer를 매칭시킨 VC를 메서드들을 호출할 수가 없었는데 instantiateViewController(withIdentifier:)로 접근하는 방법을 서칭하였고 각 VC의 id를 설정하여 접근할 수 있도록 구현하였다.

## 질문거리
- 상위 VC에서 PockerGame의 인스턴스를 생성한 뒤, 하위 뷰들의 VC에 필요한 Players, Dealer 인스턴스의 참조 주소를 넘겨주는 방식으로 구현하였습니다만 View 생성 시, 하위 뷰의 viewDidLoad가 호출된 이후에 상위 뷰의 viewDidLoad가 호출되다보니 적절한 순간에 필요 인스턴스의 참조 주소가 없어 StackView나 ImageView 등이 생성되지 않고 있습니다.
여러 방법을 통해 내부 View들이 노출되도록 시도해보았지만 전혀 차도가 없어, 정확히 어떤 부분들이 문제가 있고 이를 해결하기 위한 접근 방식을 여쭤보고자 미완성이지만 부득이하게 PR을 올립니다.